### PR TITLE
Фввув openy_ckeditor as dependency since it renders content inside.

### DIFF
--- a/openy_block/modules/openy_block_branch_amenities/openy_block_branch_amenities.info.yml
+++ b/openy_block/modules/openy_block_branch_amenities/openy_block_branch_amenities.info.yml
@@ -15,4 +15,5 @@ dependencies:
   - openy_block_custom_simple:openy_block_custom_simple
   - paragraphs:paragraphs
   - plugin:plugin
+  - openy_ckeditor
 core_incompatible: false


### PR DESCRIPTION
If openy_ckeditor is not enabled amenities block doesn't work properly

![image](https://user-images.githubusercontent.com/3023950/125594496-f3b1115d-0b72-4c51-9236-45880c5c6020.png)
