### PR TITLE
[MAINTAIN-151] changed a default value of the frameborder attribute to 1 for video_embed_iframe element

### DIFF
--- a/openy_media/modules/openy_media_video/openy_media_video.module
+++ b/openy_media/modules/openy_media_video/openy_media_video.module
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Open Y Media Video module file.
+ */
+
+use Drupal\openy_media_video\OpenyMediaVideoPreRender;
+
+/**
+ * Implements hook_element_info_alter().
+ */
+function openy_media_video_element_info_alter(&$info) {
+  if (isset($info['video_embed_iframe'])) {
+    $info['video_embed_iframe']['#pre_render'][] =
+      [
+        OpenyMediaVideoPreRender::class, 'videoEmbedIframePrerender'
+      ];
+  }
+}

--- a/openy_media/modules/openy_media_video/openy_media_video.module
+++ b/openy_media/modules/openy_media_video/openy_media_video.module
@@ -12,9 +12,9 @@ use Drupal\openy_media_video\OpenyMediaVideoPreRender;
  */
 function openy_media_video_element_info_alter(&$info) {
   if (isset($info['video_embed_iframe'])) {
-    $info['video_embed_iframe']['#pre_render'][] =
-      [
-        OpenyMediaVideoPreRender::class, 'videoEmbedIframePrerender'
-      ];
+    array_unshift(
+      $info['video_embed_iframe']['#pre_render'],
+      [OpenyMediaVideoPreRender::class, 'videoEmbedIframePrerender']
+    );
   }
 }

--- a/openy_media/modules/openy_media_video/src/OpenyMediaVideoPreRender.php
+++ b/openy_media/modules/openy_media_video/src/OpenyMediaVideoPreRender.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\openy_media_video;
+
+use Drupal\Core\Render\Element\RenderCallbackInterface;
+
+/**
+ * Implements prerender callbacks for the openy_media_video module.
+ *
+ * @internal
+ */
+class OpenyMediaVideoPreRender implements RenderCallbackInterface {
+
+  /**
+   * Prerender callback for change default value of frameborder attribute.
+   *
+   * @param array $element
+   *   A renderable array.
+   *
+   * @return array
+   *   The updated renderable array containing the frameborder attribute.
+   */
+  public static function videoEmbedIframePrerender(array $element) {
+    if (isset($element['#attributes']['frameborder'])) {
+      $element['#attributes']['frameborder'] = 1;
+    }
+    return $element;
+  }
+
+}


### PR DESCRIPTION
Original Issue, this PR is going to fix: [MAINTAIN-151](https://openy.atlassian.net/browse/MAINTAIN-151)

Also this was discussed in this PR https://github.com/ymcatwincities/openy/pull/2526

The fix should add the border to all embedded video entities
![MAINTAIN-151BorderInEmbededVideo](https://user-images.githubusercontent.com/744406/127873175-125a1436-2036-4ec5-aed6-89bd1ca8cb4d.png)

## Steps for review

- [ ] log as admin
- [ ] go to edit node (blog post foe example)
- [ ] to add a new External video entity
![MAINTAIN-151AddEmbededVideo](https://user-images.githubusercontent.com/744406/127873475-986d943f-49a8-41e3-9c53-de34bcbb9602.png)

- [ ] save node and verify that iframe has border=1
![MAINTAIN-151BorderInEmbededVideo](https://user-images.githubusercontent.com/744406/127873598-4d574701-1a96-4a00-98d0-0c678b741167.png)

- [ ] verify that for all themes
