### PR TITLE
Ability to change the link text for "Directions" [YUOPENY-14]

### DIFF
--- a/openy_block/modules/openy_block_branch_contacts_info/src/Plugin/Block/BranchContactsInfo.php
+++ b/openy_block/modules/openy_block_branch_contacts_info/src/Plugin/Block/BranchContactsInfo.php
@@ -114,8 +114,9 @@ class BranchContactsInfo extends BlockBase implements ContainerFactoryPluginInte
 
     $render_array['#fax'] = $node->field_location_fax->value;
     $render_array['#email'] = $node->field_location_email->value;
-    $render_array['#directions_field_title'] = $node->field_location_directions->title;
+    $render_array['#directions_field_title'] = $node->field_location_directions->title ?? $this->t('Directions');
     $render_array['#directions_field_url'] = $node->field_location_directions->url;
+    $render_array['#directions_url'] = $node->field_location_directions->url ?? $render_array['#directions_url'];
 
     $render_array['#branch_title'] = $node->getTitle();
     $branch_selector = openy_branch_selector_get_link($node->id());

--- a/openy_block/modules/openy_block_branch_contacts_info/templates/block-branch-contacts-info.html.twig
+++ b/openy_block/modules/openy_block_branch_contacts_info/templates/block-branch-contacts-info.html.twig
@@ -62,7 +62,7 @@
       <a href="{{ directions_url }}" target="_blank"><i class="fas fa-map-marker-alt"></i></a>
       <address class="wrapper-field-location-address">{{ address_title }}</address>
       <div class="wrapper-get-directions">
-        <a href="{{ directions_url }}" target="_blank" class="location-branch-directions-link">{{ 'Directions'|t }}</a>
+        <a href="{{ directions_url }}" target="_blank" class="location-branch-directions-link">{{ directions_field_title }}</a>
       </div>
     </div>
   {% endif %}

--- a/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_directions.yml
+++ b/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_directions.yml
@@ -16,7 +16,7 @@ field_name: field_location_directions
 entity_type: node
 bundle: branch
 label: Directions
-description: 'Directions link is auto generated from the Address field, however you can put here your own link. Otherwise please use <nolink> placeholder.'
+description: 'Directions link is auto generated from the Address field, however you can put your own link here. For no link, enter: <nolink>.'
 required: false
 translatable: true
 default_value:

--- a/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_directions.yml
+++ b/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_directions.yml
@@ -16,10 +16,18 @@ field_name: field_location_directions
 entity_type: node
 bundle: branch
 label: Directions
-description: 'To remove the "Get Directions" link from the location page, just leave URL and Link text fields blank.'
+description: 'Directions link is auto generated from the Address field, however you can put here your own link. Otherwise please use <nolink> placeholder.'
 required: false
 translatable: true
-default_value: {  }
+default_value:
+  -
+    attributes: {  }
+    uri: 'route:<nolink>'
+    title: Directions
+    options:
+      attributes:
+        class:
+          - ''
 default_value_callback: ''
 settings:
   title: 1

--- a/openy_location/modules/openy_loc_branch/openy_loc_branch.install
+++ b/openy_location/modules/openy_loc_branch/openy_loc_branch.install
@@ -522,3 +522,25 @@ function openy_loc_branch_update_8025() {
     }
   }
 }
+
+/**
+ * Directions field default values.
+ */
+function openy_loc_branch_update_8026() {
+  $config_dir = \Drupal::service('extension.list.module')->getPath('openy_loc_branch') . '/config/install/';
+  // Update multiple configurations.
+  $configs = [
+    'field.field.node.branch.field_location_directions' =>[
+      'description',
+      'default_value'
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}

--- a/openy_location/modules/openy_loc_camp/config/install/field.field.node.camp.field_location_directions.yml
+++ b/openy_location/modules/openy_loc_camp/config/install/field.field.node.camp.field_location_directions.yml
@@ -15,10 +15,18 @@ field_name: field_location_directions
 entity_type: node
 bundle: camp
 label: Directions
-description: ''
+description: 'Directions link is auto generated from the Address field, however you can put here your own link. Otherwise please use <nolink> placeholder.'
 required: false
 translatable: true
-default_value: {  }
+default_value:
+  -
+    attributes: {  }
+    uri: 'route:<nolink>'
+    title: Directions
+    options:
+      attributes:
+        class:
+          - ''
 default_value_callback: ''
 settings:
   link_type: 17

--- a/openy_location/modules/openy_loc_camp/config/install/field.field.node.camp.field_location_directions.yml
+++ b/openy_location/modules/openy_loc_camp/config/install/field.field.node.camp.field_location_directions.yml
@@ -15,7 +15,7 @@ field_name: field_location_directions
 entity_type: node
 bundle: camp
 label: Directions
-description: 'Directions link is auto generated from the Address field, however you can put here your own link. Otherwise please use <nolink> placeholder.'
+description: 'Directions link is auto generated from the Address field, however you can put your own link here. For no link, enter: <nolink>.'
 required: false
 translatable: true
 default_value:

--- a/openy_location/modules/openy_loc_camp/openy_loc_camp.install
+++ b/openy_location/modules/openy_loc_camp/openy_loc_camp.install
@@ -330,3 +330,25 @@ function openy_loc_camp_update_8014() {
     }
   }
 }
+
+/**
+ * Directions field default values.
+ */
+function openy_loc_camp_update_8015() {
+  $config_dir = \Drupal::service('extension.list.module')->getPath('openy_loc_camp') . '/config/install/';
+  // Update multiple configurations.
+  $configs = [
+    'field.field.node.camp.field_location_directions' =>[
+      'description',
+      'default_value'
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}

--- a/openy_location/modules/openy_loc_facility/config/install/field.field.node.facility.field_location_directions.yml
+++ b/openy_location/modules/openy_loc_facility/config/install/field.field.node.facility.field_location_directions.yml
@@ -15,10 +15,18 @@ field_name: field_location_directions
 entity_type: node
 bundle: facility
 label: Directions
-description: ''
+description: 'Directions link is auto generated from the Address field, however you can put here your own link. Otherwise please use <nolink> placeholder.'
 required: false
 translatable: true
-default_value: {  }
+default_value:
+  -
+    attributes: {  }
+    uri: 'route:<nolink>'
+    title: Directions
+    options:
+      attributes:
+        class:
+          - ''
 default_value_callback: ''
 settings:
   link_type: 17

--- a/openy_location/modules/openy_loc_facility/config/install/field.field.node.facility.field_location_directions.yml
+++ b/openy_location/modules/openy_loc_facility/config/install/field.field.node.facility.field_location_directions.yml
@@ -15,7 +15,7 @@ field_name: field_location_directions
 entity_type: node
 bundle: facility
 label: Directions
-description: 'Directions link is auto generated from the Address field, however you can put here your own link. Otherwise please use <nolink> placeholder.'
+description: 'Directions link is auto generated from the Address field, however you can put your own link here. For no link, enter: <nolink>.'
 required: false
 translatable: true
 default_value:

--- a/openy_location/modules/openy_loc_facility/openy_loc_facility.install
+++ b/openy_location/modules/openy_loc_facility/openy_loc_facility.install
@@ -309,3 +309,25 @@ function openy_loc_facility_update_8015() {
     }
   }
 }
+
+/**
+ * Directions field default values.
+ */
+function openy_loc_facility_update_8016() {
+  $config_dir = \Drupal::service('extension.list.module')->getPath('openy_loc_facility') . '/config/install/';
+  // Update multiple configurations.
+  $configs = [
+    'field.field.node.facility.field_location_directions' =>[
+      'description',
+      'default_value'
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}


### PR DESCRIPTION
Steps to test:

- [ ] Login as admin
- [ ] Edit any Location node
- [ ] Update `CONTACT INFO > DIRECTIONS > Link text` field value
- [ ] Verify on the front-end that Directions link text changed to new value

Themes changes are required and will be provided through Merge requests on Drupal.org. 
Upgrade path possibly is required as well, at the moment solution works well for the clean OpenY installation.