### PR TITLE
Improvements for displaying Branch location holiday hours [YUOPENY-11]

### DIFF
--- a/openy_block/modules/openy_block_branch_contacts_info/src/Plugin/Block/BranchContactsInfo.php
+++ b/openy_block/modules/openy_block_branch_contacts_info/src/Plugin/Block/BranchContactsInfo.php
@@ -126,6 +126,26 @@ class BranchContactsInfo extends BlockBase implements ContainerFactoryPluginInte
         'type' => 'openy_today_custom_hours',
         'settings' => [],
       ]);
+    }
+
+    if ($node->hasField('field_branch_holiday_hours') && isset($branch_hours)) {
+      $holiday_hours = $node->get('field_branch_holiday_hours')->view([
+        'type' => 'openy_holiday_hours',
+        'settings' => [],
+      ]);
+      if ($holiday_hours[0]['#rows']) {
+        $branch_hours[0]['#week'] += [
+          'title_holidays' => [
+            '#type' => 'html_tag',
+            '#tag' => 'h5',
+            '#value' => $this->t('Holiday Hours'),
+          ],
+          'table_holidays' => $holiday_hours[0],
+        ];
+      }
+    }
+
+    if (isset($branch_hours)) {
       $render_array['#branch_hours'] = $this->renderer->render($branch_hours);
     }
 

--- a/openy_location/modules/openy_loc_branch/config/install/core.entity_form_display.node.branch.default.yml
+++ b/openy_location/modules/openy_loc_branch/config/install/core.entity_form_display.node.branch.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.node.branch.field_bottom_content
+    - field.field.node.branch.field_branch_holiday_hours
     - field.field.node.branch.field_branch_hours
     - field.field.node.branch.field_content
     - field.field.node.branch.field_header_content
@@ -26,6 +27,7 @@ dependencies:
     - link_attributes
     - metatag
     - openy_field_custom_hours
+    - openy_field_holiday_hours
     - paragraphs
     - path
     - scheduler
@@ -71,6 +73,7 @@ third_party_settings:
     group_branch_hours:
       children:
         - field_branch_hours
+        - field_branch_holiday_hours
       parent_name: ''
       weight: 16
       format_type: tab
@@ -170,13 +173,18 @@ content:
       form_display_mode: default
       default_paragraph_type: ''
     third_party_settings: {  }
+  field_branch_holiday_hours:
+    type: openy_holiday_hours_default
+    weight: 4
     region: content
-  field_branch_hours:
-    weight: 3
     settings: {  }
     third_party_settings: {  }
+  field_branch_hours:
     type: openy_custom_hours_default
+    weight: 3
     region: content
+    settings: {  }
+    third_party_settings: {  }
   field_content:
     type: entity_reference_paragraphs
     weight: 5

--- a/openy_location/modules/openy_loc_branch/config/install/core.entity_view_display.node.branch.class_location.yml
+++ b/openy_location/modules/openy_loc_branch/config/install/core.entity_view_display.node.branch.class_location.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.class_location
     - field.field.node.branch.field_bottom_content
+    - field.field.node.branch.field_branch_holiday_hours
     - field.field.node.branch.field_branch_hours
     - field.field.node.branch.field_content
     - field.field.node.branch.field_header_content
@@ -66,6 +67,7 @@ content:
     region: content
 hidden:
   field_bottom_content: true
+  field_branch_holiday_hours: true
   field_content: true
   field_header_content: true
   field_location_amenities: true

--- a/openy_location/modules/openy_loc_branch/config/install/core.entity_view_display.node.branch.default.yml
+++ b/openy_location/modules/openy_loc_branch/config/install/core.entity_view_display.node.branch.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.node.branch.field_bottom_content
+    - field.field.node.branch.field_branch_holiday_hours
     - field.field.node.branch.field_branch_hours
     - field.field.node.branch.field_content
     - field.field.node.branch.field_header_content
@@ -25,6 +26,7 @@ dependencies:
     - geolocation
     - metatag
     - openy_field_custom_hours
+    - openy_field_holiday_hours
     - telephone
     - user
 id: node.branch.default
@@ -49,12 +51,19 @@ content:
       link: ''
     third_party_settings: {  }
     region: content
-  field_branch_hours:
-    weight: 6
+  field_branch_holiday_hours:
+    type: openy_holiday_hours
     label: above
     settings: {  }
     third_party_settings: {  }
+    weight: 6
+    region: content
+  field_branch_hours:
     type: openy_custom_hours_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 5
     region: content
   field_content:
     type: entity_reference_revisions_entity_view

--- a/openy_location/modules/openy_loc_branch/config/install/core.entity_view_display.node.branch.full.yml
+++ b/openy_location/modules/openy_loc_branch/config/install/core.entity_view_display.node.branch.full.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.branch.field_bottom_content
+    - field.field.node.branch.field_branch_holiday_hours
     - field.field.node.branch.field_branch_hours
     - field.field.node.branch.field_content
     - field.field.node.branch.field_header_content
@@ -138,6 +139,7 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  field_branch_holiday_hours: true
   field_location_area: true
   field_location_coordinates: true
   field_location_state: true

--- a/openy_location/modules/openy_loc_branch/config/install/core.entity_view_display.node.branch.sidebar_teaser.yml
+++ b/openy_location/modules/openy_loc_branch/config/install/core.entity_view_display.node.branch.sidebar_teaser.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.sidebar_teaser
     - field.field.node.branch.field_bottom_content
+    - field.field.node.branch.field_branch_holiday_hours
     - field.field.node.branch.field_branch_hours
     - field.field.node.branch.field_content
     - field.field.node.branch.field_header_content
@@ -84,6 +85,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_bottom_content: true
+  field_branch_holiday_hours: true
   field_content: true
   field_header_content: true
   field_location_amenities: true

--- a/openy_location/modules/openy_loc_branch/config/install/core.entity_view_display.node.branch.teaser.yml
+++ b/openy_location/modules/openy_loc_branch/config/install/core.entity_view_display.node.branch.teaser.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.branch.field_bottom_content
+    - field.field.node.branch.field_branch_holiday_hours
     - field.field.node.branch.field_branch_hours
     - field.field.node.branch.field_content
     - field.field.node.branch.field_header_content
@@ -84,6 +85,7 @@ content:
     region: content
 hidden:
   field_bottom_content: true
+  field_branch_holiday_hours: true
   field_content: true
   field_header_content: true
   field_location_amenities: true

--- a/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_branch_holiday_hours.yml
+++ b/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_branch_holiday_hours.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_branch_holiday_hours
+    - node.type.branch
+  module:
+    - datalayer
+    - openy_field_holiday_hours
+third_party_settings:
+  datalayer:
+    expose: 1
+    label: field_branch_holiday_hours
+id: node.branch.field_branch_holiday_hours
+field_name: field_branch_holiday_hours
+entity_type: node
+bundle: branch
+label: 'Branch Holiday Hours'
+description: 'Fill in Branch Holiday Hours. If upcoming Holiday date is less then 2 week ahead of current date, it will appear on the site.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: openy_holiday_hours

--- a/openy_location/modules/openy_loc_branch/config/install/field.storage.node.field_branch_holiday_hours.yml
+++ b/openy_location/modules/openy_loc_branch/config/install/field.storage.node.field_branch_holiday_hours.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - openy_field_holiday_hours
+id: node.field_branch_holiday_hours
+field_name: field_branch_holiday_hours
+entity_type: node
+type: openy_holiday_hours
+settings: {  }
+module: openy_field_holiday_hours
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/openy_location/modules/openy_loc_branch/openy_loc_branch.install
+++ b/openy_location/modules/openy_loc_branch/openy_loc_branch.install
@@ -486,3 +486,39 @@ function openy_loc_branch_update_8024() {
     'field.field.node.branch.field_location_directions',
   ]);
 }
+
+/**
+ * Added Branch Holiday Hours field.
+ */
+function openy_loc_branch_update_8025() {
+  $config_dir = \Drupal::service('extension.list.module')->getPath('openy_loc_branch') . '/config/install/';
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'field.storage.node.field_branch_holiday_hours',
+    'field.field.node.branch.field_branch_holiday_hours',
+    'core.entity_view_display.node.branch.class_location',
+    'core.entity_view_display.node.branch.full',
+    'core.entity_view_display.node.branch.sidebar_teaser',
+    'core.entity_view_display.node.branch.teaser',
+  ]);
+
+  // Update multiple configurations.
+  $configs = [
+    'core.entity_form_display.node.branch.default' => [
+      'third_party_settings.field_group.group_branch_hours',
+      'content',
+    ],
+    'core.entity_view_display.node.branch.default' => [
+      'content'
+    ]
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}


### PR DESCRIPTION
To test use fresh OpenY setup with Demo content.

- [ ] Login as admin user
- [ ] Edit any Location
- [ ] Fill in few **Branch Holiday Hours** in the **Branch Hours** section and save. N.B. The Date field for the **Holiday Hours** item should be set to less then 2 weeks ahead and 24h behind current date to appear on the site (business logic).
- [ ] Verify **Holiday hours** appear in the `TODAY'S HOURS > View all hours` dropdown