### PR TITLE
[DS-331] Remove filter_htmlcorrector from Code filter

### DIFF
--- a/openy_block/modules/openy_code_block/config/install/filter.format.code.yml
+++ b/openy_block/modules/openy_code_block/config/install/filter.format.code.yml
@@ -7,12 +7,6 @@ name: Code
 format: code
 weight: 20
 filters:
-  filter_htmlcorrector:
-    id: filter_htmlcorrector
-    provider: filter
-    status: true
-    weight: 10
-    settings: {  }
   entity_embed:
     id: entity_embed
     provider: entity_embed

--- a/openy_block/modules/openy_code_block/openy_code_block.install
+++ b/openy_block/modules/openy_code_block/openy_code_block.install
@@ -25,3 +25,24 @@ function openy_code_block_update_8001() {
     }
   }
 }
+
+/**
+ * Remove filter_htmlcorrector to enable pasting embeds.
+ */
+function openy_code_block_update_8002() {
+  $config_dir = \Drupal::service('extension.list.module')->getPath('openy_code_block') . '/config/install/';
+  // Update multiple configurations.
+  $configs = [
+    'filter.format.code' => [
+      'filters',
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}


### PR DESCRIPTION
Resolves https://yusa.atlassian.net/browse/DS-331

The  `filter_htmlcorrector` in the Code Block is preventing direct pasting of embed codes from GXP (and possibly other places). As discussed in Slack this filter is unnecessary in the Code Block and can be removed.

To test:
- pull code and run `updb`
- visit `admin/config/content/formats/manage/code` and observe "Correct faulty and chopped off HTML" is unchecked.