### PR TITLE
fix: enable openy_field_holiday_hours

### DIFF
--- a/openy_location/modules/openy_loc_branch/openy_loc_branch.install
+++ b/openy_location/modules/openy_loc_branch/openy_loc_branch.install
@@ -491,6 +491,7 @@ function openy_loc_branch_update_8024() {
  * Added Branch Holiday Hours field.
  */
 function openy_loc_branch_update_8025() {
+  \Drupal::service('module_installer')->install(['openy_field_holiday_hours']);
   $config_dir = \Drupal::service('extension.list.module')->getPath('openy_loc_branch') . '/config/install/';
   $config_importer = \Drupal::service('openy_upgrade_tool.importer');
   $config_importer->setDirectory($config_dir);


### PR DESCRIPTION
Previously if a site without openy_field_holiday_hours enabled ran the 8025 update, the configuration dependent on that module wouldn't be imported.

This doesn't do anything to address sites that have already run the 8025 update.

See also
- this Slack discussion: https://yusaslackinstance.slack.com/archives/C03E6SQQ0Q5/p1680083553972689
- https://github.com/YCloudYUSA/y_lb/issues/59 which has a similar open question about resolution imho.

Thanks!