### PR TITLE
#38: Add guards to node batch updates

### DIFF
--- a/openy_node/modules/openy_node_activity/openy_node_activity.module
+++ b/openy_node/modules/openy_node_activity/openy_node_activity.module
@@ -36,6 +36,9 @@ function openy_node_activity_node_update(Drupal\Core\Entity\EntityInterface $ent
   }
 
   $activity_ids = _openy_node_activity_getactivitynodes($entity);
+  if (!$activity_ids) {
+    return;
+  }
   $batch = [
     'title' => t('Updating @type...', ['@type' => 'activities']),
     'operations' => [

--- a/openy_node/modules/openy_node_category/openy_node_category.module
+++ b/openy_node/modules/openy_node_category/openy_node_category.module
@@ -36,6 +36,9 @@ function openy_node_category_node_update(Drupal\Core\Entity\EntityInterface $ent
   }
 
   $category_ids = _openy_node_category_getcategorynodes($entity);
+  if (!$category_ids) {
+    return;
+  }
   $batch = [
     'title' => t('Updating @type...', ['@type' => 'categories']),
     'operations' => [

--- a/openy_node/modules/openy_node_class/openy_node_class.module
+++ b/openy_node/modules/openy_node_class/openy_node_class.module
@@ -36,6 +36,9 @@ function openy_node_class_node_update(Drupal\Core\Entity\EntityInterface $entity
   }
 
   $class_ids = _openy_node_class_getclassnodes($entity);
+  if (!$class_ids) {
+    return;
+  }
   $batch = [
     'title' => t('Updating @type...', ['@type' => 'classes']),
     'operations' => [

--- a/openy_node/src/BatchNodeUpdate.php
+++ b/openy_node/src/BatchNodeUpdate.php
@@ -34,6 +34,7 @@ class BatchNodeUpdate {
     $batch_ids = array_slice($ids, $context['sandbox']['progress'], $items_per_iteration);
     $nodes = \Drupal::entityTypeManager()->getStorage('node')->loadMultiple($batch_ids);
 
+    $context['results']['ids'] = [];
     foreach ($nodes as $node) {
       if ($status && !$node->isPublished()) {
         // Publish all Activity nodes.


### PR DESCRIPTION
**Ticket:** #38

Don't set batch updates with nothing to do. Don't error out if nothing can be loaded in the batch callback.

Thanks!