### PR TITLE
DS-825 Move event listing placeholder text to label

### DIFF
--- a/openy_prgf/modules/openy_prgf_event_listing/openy_prgf_event_listing.module
+++ b/openy_prgf/modules/openy_prgf_event_listing/openy_prgf_event_listing.module
@@ -13,6 +13,6 @@ function openy_prgf_event_listing_form_views_exposed_form_alter(&$form, \Drupal\
 
   // Add placeholder to views exposed form
   if ($view->id() == 'listing_event_posts' && $view->current_display == 'events_listing_block') {
-    $form['combine']['#attributes']['placeholder'] = t('Search the events...');
+    $form['combine']['#title'] = t('Search the events:');
   }
 }


### PR DESCRIPTION
[DS-825](https://yusa.atlassian.net/browse/DS-825) [Accessibility] Event Post Listing (paragraphs) missing form label

Changes inaccessible placeholder title to a proper label for proper accessibility.

![Events___Drush_Site-Install](https://github.com/open-y-subprojects/openy_features/assets/238201/82d80244-8677-478e-9558-5e8743c2401c)

