### PR TITLE
fix: Restore FAQ accordion functionality in D10

### DIFF
--- a/openy_prgf/modules/openy_prgf_faq/js/paragraph.js
+++ b/openy_prgf/modules/openy_prgf_faq/js/paragraph.js
@@ -5,7 +5,8 @@
 (function ($) {
   Drupal.behaviors.openyFaqParagraph = {
     attach: function( context ) {
-      $( context ).find( '.paragraph--type--faq-item' ).once( 'paragraphFaq' ).each( function () {
+      $(once('paragraphFaq', '.paragraph--type--faq-item', context))
+        .each(function () {
         // Q/A wrapper.
         var wrapper = $( this );
         // Question click event.

--- a/openy_prgf/modules/openy_prgf_faq/openy_prgf_faq.libraries.yml
+++ b/openy_prgf/modules/openy_prgf_faq/openy_prgf_faq.libraries.yml
@@ -2,3 +2,6 @@ paragraph:
   version: 1.x
   js:
     js/paragraph.js: {}
+  dependencies:
+    - core/jquery
+    - core/once


### PR DESCRIPTION
As per https://www.drupal.org/node/3158256

FAQ accordions failed in D10 with `Uncaught TypeError: once is not a function` This resolved the issue.