### PR TITLE
DS-858 Move addtocalendar js to openy_system

### DIFF
--- a/openy_node/modules/openy_node_event/js/openy_node_event.js
+++ b/openy_node/modules/openy_node_event/js/openy_node_event.js
@@ -22,25 +22,4 @@
     }
   };
 
-  Drupal.behaviors.atcFix = {
-    attach: function (context, settings) {
-      $('.addtocalendar').click(function() {
-        if ($(this).hasClass('activated')) {
-          $(this).removeClass('activated');
-          $(this).find('.atcb-list').css({
-            'display' : 'none',
-            'visibility' : 'hidden'
-          });
-        }
-        else {
-          $(this).addClass('activated');
-          $(this).find('.atcb-list').css({
-            'display' : 'block',
-            'visibility' : 'visible'
-          });
-        }
-      });
-    }
-  };
-
 })(jQuery);

--- a/openy_node/modules/openy_node_event/openy_node_event.info.yml
+++ b/openy_node/modules/openy_node_event/openy_node_event.info.yml
@@ -26,3 +26,4 @@ dependencies:
   - drupal:text
   - drupal:user
   - openy_er:openy_er
+  - openy_system:openy_system

--- a/openy_node/modules/openy_node_event/openy_node_event.libraries.yml
+++ b/openy_node/modules/openy_node_event/openy_node_event.libraries.yml
@@ -1,11 +1,3 @@
-atc_base:
-  version: 1.5
-  css:
-    component:
-      '//addtocalendar.com/atc/1.5/atc-base.css': {type: external}
-  js:
-    '//addtocalendar.com/atc/1.5/atc.min.js': { type: external, minified: true }
-
 atc_glow_orange:
   version: 1.5
   css:

--- a/openy_node/modules/openy_node_event/openy_node_event.module
+++ b/openy_node/modules/openy_node_event/openy_node_event.module
@@ -140,7 +140,7 @@ function openy_node_event_preprocess_field__node__field_event_location__event(&$
     ];
   }
 
-  $variables['#attached']['library'][] = 'openy_node_event/atc_base';
+  $variables['#attached']['library'][] = 'openy_system/atc_base';
   $variables['#attached']['library'][] = 'openy_node_event/event_custom';
 }
 


### PR DESCRIPTION
In order to improve accessibility of the addtocalendar functionality (that's mostly no longer maintained) I've moved that JS into https://github.com/froboy/openy_custom/tree/main/openy_system. Many modules have indirect dependencies there, but this formalizes that dependency.