### PR TITLE
fix: Update image style sizes as per 2023 recommendations

### DIFF
--- a/openy_node/config/install/image.style.facebook.yml
+++ b/openy_node/config/install/image.style.facebook.yml
@@ -9,8 +9,8 @@ effects:
     id: image_scale
     weight: 1
     data:
-      width: 600
-      height: 315
+      width: 1200
+      height: 630
       upscale: false
   5cc7aae0-016e-4841-8ca9-556674060bf3:
     uuid: 5cc7aae0-016e-4841-8ca9-556674060bf3

--- a/openy_node/openy_node.install
+++ b/openy_node/openy_node.install
@@ -148,3 +148,15 @@ function openy_node_update_8009() {
     'image.style.facebook',
   ]);
 }
+
+/**
+ * Update to 2023 recommended image size.
+ */
+function openy_node_update_8010() {
+  $path = \Drupal::service('extension.list.module')->getPath('openy_node') . '/config/install';
+  $config_importer = \Drupal::service('config_import.importer');
+  $config_importer->setDirectory($path);
+  $config_importer->importConfigs([
+    'image.style.facebook',
+  ]);
+}


### PR DESCRIPTION
See https://developers.facebook.com/docs/sharing/webmasters/images/

> Use images that are at least 1200 x 630 pixels for the best display on high resolution devices. At the minimum, you should use images that are 600 x 315 pixels to display link page posts with larger images.
