### PR TITLE
DS-675 feat: DS-675 Add schema for branch, camp, facility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "open-y-subprojects/openy_features",
-  "description": "Features from Open Y Distrubution.",
+  "description": "Features from Open Y Distribution.",
   "type": "drupal-module",
   "require": {
     "drupal/ckeditor5_font": "^1.1@beta",
@@ -8,6 +8,8 @@
     "drupal/ctools": ">=3.13",
     "drupal/google_analytics": "^4.0.2",
     "drupal/rabbit_hole": "^1.0@beta || ^1.0",
+    "drupal/metatag": "*",
+    "drupal/schema_metatag": "^3.0",
     "open-y-subprojects/openy_custom": ">=2.1.0",
     "open-y-subprojects/openy_demo_content": "^1.12",
     "open-y-subprojects/openy_node_alert": "^2.0",

--- a/openy_location/modules/openy_loc_branch/config/optional/metatag.metatag_defaults.node__branch.yml
+++ b/openy_location/modules/openy_loc_branch/config/optional/metatag.metatag_defaults.node__branch.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__branch
+label: 'Content: Branch'
+tags:
+  schema_organization_address: 'a:6:{s:5:"@type";s:13:"PostalAddress";s:13:"streetAddress";s:43:"[node:field_location_address:address_line1]";s:15:"addressLocality";s:38:"[node:field_location_address:locality]";s:13:"addressRegion";s:49:"[node:field_location_address:administrative_area]";s:10:"postalCode";s:41:"[node:field_location_address:postal_code]";s:14:"addressCountry";s:42:"[node:field_location_address:country_name]";}'
+  schema_organization_description: '[current-page:metatag:description]'
+  schema_organization_geo: 'a:3:{s:5:"@type";s:14:"GeoCoordinates";s:8:"latitude";s:37:"[node:field_location_coordinates:lat]";s:9:"longitude";s:37:"[node:field_location_coordinates:lng]";}'
+  schema_organization_id: '[current-page:url]'
+  schema_organization_logo: 'a:3:{s:5:"@type";s:11:"ImageObject";s:20:"representativeOfPage";s:5:"False";s:3:"url";s:49:"[site:url]themes/contrib/openy_carnation/logo.svg";}'
+  schema_organization_name: '[current-page:title]'
+  schema_organization_opening_hours_specification: 'a:5:{s:5:"@type";s:25:"OpeningHoursSpecification";s:5:"pivot";s:1:"1";s:9:"dayOfWeek";s:25:"[openy_hours:day_of_week]";s:5:"opens";s:19:"[openy_hours:opens]";s:6:"closes";s:20:"[openy_hours:closes]";}'
+  schema_organization_telephone: '[node:field_location_phone]'
+  schema_organization_type: LocalBusiness
+  schema_organization_url: '[current-page:url]'

--- a/openy_location/modules/openy_loc_branch/openy_loc_branch.install
+++ b/openy_location/modules/openy_loc_branch/openy_loc_branch.install
@@ -569,3 +569,18 @@ function openy_loc_branch_update_8027(&$sandbox) {
     }
   }
 }
+
+/**
+ * Add metatag and schema:LocalBusiness configuration.
+ */
+function openy_loc_branch_update_8028(&$sandbox) {
+  \Drupal::service('module_installer')->install(['schema_organization']);
+
+  $path = \Drupal::service('extension.list.module')->getPath('openy_loc_branch') . '/config/optional';
+  /** @var \Drupal\config_import\ConfigImporterService $config_importer */
+  $config_importer = \Drupal::service('config_import.importer');
+  $config_importer->setDirectory($path);
+  $config_importer->importConfigs([
+    'metatag.metatag_defaults.node__branch',
+  ]);
+}

--- a/openy_location/modules/openy_loc_camp/config/optional/metatag.metatag_defaults.node__camp.yml
+++ b/openy_location/modules/openy_loc_camp/config/optional/metatag.metatag_defaults.node__camp.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__camp
+label: 'Content: Camp'
+tags:
+  schema_organization_address: 'a:6:{s:5:"@type";s:13:"PostalAddress";s:13:"streetAddress";s:43:"[node:field_location_address:address_line1]";s:15:"addressLocality";s:38:"[node:field_location_address:locality]";s:13:"addressRegion";s:49:"[node:field_location_address:administrative_area]";s:10:"postalCode";s:41:"[node:field_location_address:postal_code]";s:14:"addressCountry";s:42:"[node:field_location_address:country_name]";}'
+  schema_organization_description: '[current-page:metatag:description]'
+  schema_organization_geo: 'a:3:{s:5:"@type";s:14:"GeoCoordinates";s:8:"latitude";s:37:"[node:field_location_coordinates:lat]";s:9:"longitude";s:37:"[node:field_location_coordinates:lng]";}'
+  schema_organization_id: '[current-page:url]'
+  schema_organization_logo: 'a:3:{s:5:"@type";s:11:"ImageObject";s:20:"representativeOfPage";s:5:"False";s:3:"url";s:49:"[site:url]themes/contrib/openy_carnation/logo.svg";}'
+  schema_organization_name: '[current-page:title]'
+  schema_organization_telephone: '[node:field_location_phone]'
+  schema_organization_type: LocalBusiness
+  schema_organization_url: '[current-page:url]'

--- a/openy_location/modules/openy_loc_camp/openy_loc_camp.install
+++ b/openy_location/modules/openy_loc_camp/openy_loc_camp.install
@@ -376,3 +376,18 @@ function openy_loc_camp_update_8016(&$sandbox) {
     }
   }
 }
+
+/**
+ * Add metatag and schema:LocalBusiness configuration.
+ */
+function openy_loc_camp_update_8017(&$sandbox) {
+  \Drupal::service('module_installer')->install(['schema_organization']);
+
+  $path = \Drupal::service('extension.list.module')->getPath('openy_loc_camp') . '/config/optional';
+  /** @var \Drupal\config_import\ConfigImporterService $config_importer */
+  $config_importer = \Drupal::service('config_import.importer');
+  $config_importer->setDirectory($path);
+  $config_importer->importConfigs([
+    'metatag.metatag_defaults.node__camp',
+  ]);
+}

--- a/openy_location/modules/openy_loc_facility/config/optional/metatag.metatag_defaults.node__facility.yml
+++ b/openy_location/modules/openy_loc_facility/config/optional/metatag.metatag_defaults.node__facility.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__facility
+label: 'Content: Facility'
+tags:
+  schema_organization_address: 'a:6:{s:5:"@type";s:13:"PostalAddress";s:13:"streetAddress";s:43:"[node:field_location_address:address_line1]";s:15:"addressLocality";s:38:"[node:field_location_address:locality]";s:13:"addressRegion";s:49:"[node:field_location_address:administrative_area]";s:10:"postalCode";s:41:"[node:field_location_address:postal_code]";s:14:"addressCountry";s:42:"[node:field_location_address:country_name]";}'
+  schema_organization_description: '[current-page:metatag:description]'
+  schema_organization_geo: 'a:3:{s:5:"@type";s:14:"GeoCoordinates";s:8:"latitude";s:37:"[node:field_location_coordinates:lat]";s:9:"longitude";s:37:"[node:field_location_coordinates:lng]";}'
+  schema_organization_id: '[current-page:url]'
+  schema_organization_logo: 'a:3:{s:5:"@type";s:11:"ImageObject";s:20:"representativeOfPage";s:5:"False";s:3:"url";s:49:"[site:url]themes/contrib/openy_carnation/logo.svg";}'
+  schema_organization_name: '[current-page:title]'
+  schema_organization_telephone: '[node:field_location_phone]'
+  schema_organization_type: LocalBusiness
+  schema_organization_url: '[current-page:url]'

--- a/openy_location/modules/openy_loc_facility/openy_loc_facility.install
+++ b/openy_location/modules/openy_loc_facility/openy_loc_facility.install
@@ -354,3 +354,18 @@ function openy_loc_facility_update_8017(&$sandbox) {
     }
   }
 }
+
+/**
+ * Add metatag and schema:LocalBusiness configuration.
+ */
+function openy_loc_facility_update_8018(&$sandbox) {
+  \Drupal::service('module_installer')->install(['schema_organization']);
+
+  $path = \Drupal::service('extension.list.module')->getPath('openy_loc_facility') . '/config/optional';
+  /** @var \Drupal\config_import\ConfigImporterService $config_importer */
+  $config_importer = \Drupal::service('config_import.importer');
+  $config_importer->setDirectory($path);
+  $config_importer->importConfigs([
+    'metatag.metatag_defaults.node__facility',
+  ]);
+}


### PR DESCRIPTION
Adds metatags using Schema:LocalBusiness to Branch, Camp, and Facility content types.

To test:
- ensure database updates are run
- go to /admin/config/search/metatag and observe new entries for Branch, Camp, Facility
- Edit a Branch and populate the Branch Hours, Save
- Put the page url into https://search.google.com/test/rich-results and observe the Rich Results return with no errors (warnings may be returned) including opening hours.
- Do the same with Camp/Facility (no hours will be displayed since these content types don't have them
- Switch a Branch to Layout Builder, retest and the metadata should not change.