### PR TITLE
DS-826 feat: Add diff module for rich revisions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "drupal/ckeditor5_font": "^1.1@beta",
     "drupal/core": "^9.5 || ^10",
     "drupal/ctools": ">=3.13",
+    "drupal/diff": "*",
     "drupal/google_analytics": "^4.0.2",
     "drupal/rabbit_hole": "^1.0@beta || ^1.0",
     "drupal/metatag": "*",

--- a/openy_node/config/install/diff.settings.yml
+++ b/openy_node/config/install/diff.settings.yml
@@ -1,0 +1,16 @@
+general_settings:
+  radio_behavior: simple
+  context_lines_leading: 1
+  context_lines_trailing: 1
+  revision_pager_limit: 50
+  layout_plugins:
+    visual_inline:
+      enabled: true
+      weight: 0
+    split_fields:
+      enabled: true
+      weight: 1
+    unified_fields:
+      enabled: true
+      weight: 2
+  visual_inline_theme: default

--- a/openy_node/openy_node.install
+++ b/openy_node/openy_node.install
@@ -160,3 +160,12 @@ function openy_node_update_8010() {
     'image.style.facebook',
   ]);
 }
+
+/**
+ * Enable diff module for better node revision interface.
+ */
+function openy_node_update_8011()
+{
+  \Drupal::service('module_installer')->install(['diff']);
+  // We are using the default config so no config import is necessary.
+}


### PR DESCRIPTION
Add [diff module](https://www.drupal.org/project/diff) for better revision comparison. It’s got 90k installs and almost zero config. Seems like a great addition for the editor experience.

To test:
- Install or update
- Edit and save a node
- Visit **Revisions** and observe that you can now compare versions.

![Revisions_for_Layout_Builder_Style_Guide___Drush_Site-Install](https://github.com/open-y-subprojects/openy_features/assets/238201/8e04b36c-72e8-43a2-a37d-c5cb63aa0af9)
