### PR TITLE
[DS-1256] Add WS colors to Ckeditor5's font color and background color plugins.

### DIFF
--- a/openy_editor/config/install/editor.editor.full_html.yml
+++ b/openy_editor/config/install/editor.editor.full_html.yml
@@ -59,7 +59,7 @@ settings:
     media_media:
       allow_view_mode_override: true
     ckeditor5_font_colors:
-      colors: '[]'
+      colors: '[{"color":"#0060af","label":"Blue A"},{"color":"#5c2e91","label":"Purple A"},{"color":"#006b6b","label":"Green A"},{"color":"#a92b31","label":"Red A"},{"color":"#4d4d4d","label":"Dim Grey"},{"color":"#999999","label":"Grey"},{"color":"#e6e6e6","label":"Light grey"},{"color":"#ffffff","label":"White"},{"color":"#e64c4c","label":"Red"},{"color":"#e6994c","label":"Orange"},{"color":"#e6e64c","label":"Yellow"},{"color":"#99e64c","label":"Light green"},{"color":"#4ce64c","label":"Green"},{"color":"#2ea09c","label":"Dark cyan"},{"color":"#4ce699","label":"Aquamarine"},{"color":"#4ce6e6","label":"Tirquuise"},{"color":"#4c99e6","label":"Light blue"},{"color":"#4c4ce6","label":"Blue"},{"color":"#994ce6","label":"Purple"}]'
     editor_advanced_link_link:
       enabled_attributes:
         - aria-label

--- a/openy_editor/openy_editor.install
+++ b/openy_editor/openy_editor.install
@@ -101,3 +101,9 @@ function openy_editor_update_9002() {
   ]);
 }
 
+/**
+ * Add WS colors to Ckeditor5 font and background color plugins.
+ */
+function openy_editor_update_9003() {
+  openy_editor_update_9002();
+}


### PR DESCRIPTION
[DS-1256](https://yusa.atlassian.net/browse/DS-1256)

How to check:
- [ ] log as admin
- [ ] go to the edit node with the bode/description field that uses WYSIWYG editor
- [ ] use Forn color or Background color buttons/plugins
- [ ] verify that first four colors are WS Primary colors
![image](https://github.com/open-y-subprojects/openy_features/assets/744406/3234b8b8-0a4d-4502-b170-39cda68bc873)
