### PR TITLE
YGBWSLA-679: Fix deprication notice in strip_tags() function

### DIFF
--- a/openy_node/modules/openy_node_event/openy_node_event.module
+++ b/openy_node/modules/openy_node_event/openy_node_event.module
@@ -65,7 +65,7 @@ function openy_node_event_preprocess_field__node__field_event_location__event(&$
     'date_start' => $startDt,
     'date_end' => $endDt,
   ];
-  $description = strip_tags($node->field_event_description->value);
+  $description = strip_tags($node->field_event_description->value ?? '');
   $description = substr($description, 0, 300);
   $description = substr($description, 0, strrpos($description, ' ')) . " ...";
   $datesAtc = [


### PR DESCRIPTION
**Steps to reproduce:**
1. Create an event with an empty description
2. Go to the review page with the error display enabled

<img width="1621" alt="Screenshot 2024-02-14 at 14 04 01" src="https://github.com/open-y-subprojects/openy_features/assets/50984627/7e30f93c-365c-4f2c-94b6-5340d4461510">
