### PR TITLE
DS-1342 fix: Enable adding local video and remote video via media directories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
     "patches": {
       "drupal/ckeditor5_font": {
         "Issue #3350333: TypeError: array_filter(): Argument #1 ($array) must be of type array.": "https://www.drupal.org/files/issues/2023-04-21/3350333-5.patch"
+      },
+      "drupal/media_directories": {
+        "https://dgo.to/3444172 Support adding media with Video Embed Field": "https://git.drupalcode.org/project/media_directories/-/merge_requests/14.diff"
       }
     }
   },

--- a/openy_media/modules/openy_media_local_video/config/install/field.field.media.video_local.field_media_local_video.yml
+++ b/openy_media/modules/openy_media_local_video/config/install/field.field.media.video_local.field_media_local_video.yml
@@ -17,7 +17,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_extensions: 'mp4 webm ogv'
+  file_extensions: 'mp4 webm ogv avi'
   file_directory: 'videos/[date:custom:Y]-[date:custom:m]'
   max_filesize: ''
   handler: 'default:file'

--- a/openy_media/modules/openy_media_local_video/config/install/field.field.media.video_local.field_media_local_video.yml
+++ b/openy_media/modules/openy_media_local_video/config/install/field.field.media.video_local.field_media_local_video.yml
@@ -17,7 +17,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_extensions: ''
+  file_extensions: 'mp4 webm ogv'
   file_directory: 'videos/[date:custom:Y]-[date:custom:m]'
   max_filesize: ''
   handler: 'default:file'

--- a/openy_media/modules/openy_media_local_video/openy_media_local_video.install
+++ b/openy_media/modules/openy_media_local_video/openy_media_local_video.install
@@ -41,3 +41,25 @@ function openy_media_local_video_update_8001() {
 function openy_media_local_video_update_9001() {
   EmbedButtonIconHelper::setEmbedButtonIcon('openy_media_local_video', 'local_video.svg', 'embed_local_video');
 }
+
+/**
+ * Add local video file extensions.
+ */
+function openy_media_local_video_update_9002()
+{
+  $config_dir = \Drupal::service('extension.list.module')->getPath('openy_media_local_video') . '/config/install/';
+  // Update multiple configurations.
+  $configs = [
+    'field.field.media.video_local.field_media_local_video' => [
+      'settings.file_extensions',
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}


### PR DESCRIPTION
- Visit /admin/content/browser
- “Add media”
- Check that “Video” accepts a youtube, vimeo, or youtube playlist
- Ensure you can add the video and then edit the metadata
- Check that “Local Video” accepts formats
- Ensure you can add the video and then edit the metadata

Adds contrib issue: https://www.drupal.org/node/3444172