### PR TITLE
[DS-1310] Add the "CKEditor 5 Paste Filter" to the Full HTML editor configuration and enable it

### DIFF
--- a/openy_editor/config/install/editor.editor.full_html.yml
+++ b/openy_editor/config/install/editor.editor.full_html.yml
@@ -60,6 +60,79 @@ settings:
       allow_view_mode_override: true
     ckeditor5_font_colors:
       colors: '[{"color":"#0060af","label":"Blue A"},{"color":"#5c2e91","label":"Purple A"},{"color":"#006b6b","label":"Green A"},{"color":"#a92b31","label":"Red A"},{"color":"#4d4d4d","label":"Dim Grey"},{"color":"#999999","label":"Grey"},{"color":"#e6e6e6","label":"Light grey"},{"color":"#ffffff","label":"White"},{"color":"#e64c4c","label":"Red"},{"color":"#e6994c","label":"Orange"},{"color":"#e6e64c","label":"Yellow"},{"color":"#99e64c","label":"Light green"},{"color":"#4ce64c","label":"Green"},{"color":"#2ea09c","label":"Dark cyan"},{"color":"#4ce699","label":"Aquamarine"},{"color":"#4ce6e6","label":"Tirquuise"},{"color":"#4c99e6","label":"Light blue"},{"color":"#4c4ce6","label":"Blue"},{"color":"#994ce6","label":"Purple"}]'
+    ckeditor5_paste_filter_pasteFilter:
+      enabled: true
+      filters:
+        -
+          enabled: true
+          weight: -10
+          search: '<o:p><\/o:p>'
+          replace: ''
+        -
+          enabled: true
+          weight: -9
+          search: '(<[^>]*) (style="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: -8
+          search: '(<[^>]*) (face="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: -7
+          search: '(<[^>]*) (class="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: -6
+          search: '(<[^>]*) (valign="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: -5
+          search: '<font[^>]*>'
+          replace: ''
+        -
+          enabled: true
+          weight: -4
+          search: '<\/font>'
+          replace: ''
+        -
+          enabled: true
+          weight: -3
+          search: '<span[^>]*>'
+          replace: ''
+        -
+          enabled: true
+          weight: -2
+          search: '<\/span>'
+          replace: ''
+        -
+          enabled: true
+          weight: -1
+          search: '<p>&nbsp;<\/p>'
+          replace: ''
+        -
+          enabled: true
+          weight: 0
+          search: '<p><\/p>'
+          replace: ''
+        -
+          enabled: true
+          weight: 1
+          search: '<b><\/b>'
+          replace: ''
+        -
+          enabled: true
+          weight: 2
+          search: '<i><\/i>'
+          replace: ''
+        -
+          enabled: true
+          weight: 3
+          search: '<a name="OLE_LINK[^"]*">(.*?)<\/a>'
+          replace: $1
     editor_advanced_link_link:
       enabled_attributes:
         - aria-label

--- a/openy_editor/openy_editor.info.yml
+++ b/openy_editor/openy_editor.info.yml
@@ -9,6 +9,7 @@ dependencies:
   - ckeditor_bootstrap_buttons:ckeditor_bootstrap_buttons
   - drupal:ckeditor5
   - drupal:ckeditor5_font
+  - drupal:ckeditor5_paste_filter
   - drupal:editor
   - ckeditor_font:ckeditor_font
   - drupal:filter

--- a/openy_editor/openy_editor.install
+++ b/openy_editor/openy_editor.install
@@ -107,3 +107,24 @@ function openy_editor_update_9002() {
 function openy_editor_update_9003() {
   openy_editor_update_9002();
 }
+
+/**
+ * Update editor settings to add Ckeditor5 paste filter.
+ */
+function openy_editor_update_91001() {
+  if (!\Drupal::moduleHandler()->moduleExists('ckeditor5_paste_filter')) {
+    \Drupal::service('module_installer')->install(['ckeditor5_paste_filter']);
+  }
+
+  $active_config = \Drupal::configFactory()->getEditable('editor.editor.full_html');
+  $plugin_manager = \Drupal::service('plugin.manager.ckeditor5.plugin');
+  $default_plugin_settings = $plugin_manager
+    ->getPlugin('ckeditor5_paste_filter_pasteFilter', NULL)
+    ->defaultConfiguration();
+  // Enable the filter.
+  $default_plugin_settings['enabled'] = TRUE;
+  $enabled_plugins = $active_config->get('settings.plugins');
+  $enabled_plugins['ckeditor5_paste_filter_pasteFilter'] = $default_plugin_settings;
+  $active_config->set('settings.plugins', $enabled_plugins);
+  $active_config->save(TRUE);
+}


### PR DESCRIPTION
Original Issue, this PR is going to fix: [DS-1310](https://yusa.atlassian.net/browse/DS-1310)

## Steps for review

- [ ] log as admin
- [ ] go to /admin/config/content/formats/manage/full_html
- [ ] verify that **Paste filter** is enabled
![image](https://github.com/YCloudYUSA/yusaopeny/assets/744406/faf0a830-fd1a-49fb-8932-7124b73b191d)

- [ ] go to /node/add/article_lb
- [ ] paste formatted text (heading, font color, color background, font size, font family etc) from MS Word or LibreOffice Write to body field
- [ ] verify that some styles are cleared
![image](https://github.com/YCloudYUSA/yusaopeny/assets/744406/b3ca1fb5-bc78-4d1f-9ecb-c9ac8414dcbb)
- [ ] save the node
- [ ] verify that the text has cleared formats (some)
- [ ] verify that others nodes and blocks in LB