### PR TITLE
ds-1549:fix for responsive image issue on ios device.

### DIFF
--- a/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_full.yml
+++ b/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_full.yml
@@ -22,7 +22,6 @@ content:
       image_style: media_full
       thumbnail_style: ''
       media_switch: ''
-      ratio: enforced
       sizes: ''
       breakpoints:
         xs:

--- a/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_half.yml
+++ b/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_half.yml
@@ -22,7 +22,6 @@ content:
       image_style: media_half
       thumbnail_style: ''
       media_switch: ''
-      ratio: enforced
       sizes: ''
       breakpoints:
         xs:

--- a/openy_media/modules/openy_media_image/openy_media_image.install
+++ b/openy_media/modules/openy_media_image/openy_media_image.install
@@ -392,7 +392,7 @@ function openy_media_image_update_8016() {
 /**
  * Update hook for media full and half settings.
  */
-function openy_media_update_10001() {
+function openy_media_image_update_10001() {
  $config_dir = \Drupal::service('extension.list.module')->getPath('openy_media_image') . '/config/install/';
   
   // List of configurations to update.

--- a/openy_media/modules/openy_media_image/openy_media_image.install
+++ b/openy_media/modules/openy_media_image/openy_media_image.install
@@ -388,3 +388,26 @@ function openy_media_image_update_8016() {
   function openy_media_image_update_9001() {
     EmbedButtonIconHelper::setEmbedButtonIcon('openy_media_image', 'image.svg', 'embed_image');
 }
+
+/**
+ * Update hook for media full and half settings.
+ */
+function openy_media_update_10001() {
+ $config_dir = \Drupal::service('extension.list.module')->getPath('openy_media_image') . '/config/install/';
+  
+  // List of configurations to update.
+  $configs = [
+    'core.entity_view_display.media.image.embedded_full',
+    'core.entity_view_display.media.image.embedded_half',
+  ];
+
+  foreach ($configs as $config_name) {
+    $config = \Drupal::configFactory()->getEditable($config_name);
+
+    if ($config->get('content.field_media_image.settings.ratio') === 'enforced') {
+      $config->clear('content.field_media_image.settings.ratio')
+        ->save();
+    }
+  }
+}
+


### PR DESCRIPTION
the images added through simple text/table are looking fine on android devices but they are not scalling well on the ios devices https://carnation-ws.y.org/events/test-event , this fix is working as expected in couple of our sites . link to issue https://yusa.atlassian.net/browse/DS-1549 