### PR TITLE
Fix image field Manage form display for News Post content type

### DIFF
--- a/openy_node/modules/openy_node_news/config/optional/core.entity_form_display.node.news.default.yml
+++ b/openy_node/modules/openy_node_news/config/optional/core.entity_form_display.node.news.default.yml
@@ -1,0 +1,239 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.images_library
+    - field.field.node.news.field_content
+    - field.field.node.news.field_meta_tags
+    - field.field.node.news.field_news_category
+    - field.field.node.news.field_news_description
+    - field.field.node.news.field_news_image
+    - field.field.node.news.field_news_location
+    - field.field.node.news.field_news_related
+    - field.field.node.news.field_sidebar_content
+    - node.type.news
+  module:
+    - entity_browser
+    - field_group
+    - metatag
+    - paragraphs
+    - path
+    - scheduler
+    - text
+third_party_settings:
+  field_group:
+    group_content_area:
+      children:
+        - field_news_image
+        - field_news_description
+        - field_content
+      label: 'Content Area'
+      region: hidden
+      parent_name: ''
+      weight: 4
+      format_type: tab
+      format_settings:
+        classes: ''
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_sidebar_area:
+      children:
+        - field_news_related
+        - field_sidebar_content
+      label: 'Sidebar Area'
+      region: hidden
+      parent_name: ''
+      weight: 5
+      format_type: tab
+      format_settings:
+        classes: ''
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+_core:
+  default_config_hash: xan-0xbL2bpydHH7nQgAqu1IICFp-ELa3sYE6Vcgj-0
+id: node.news.default
+targetEntityType: node
+bundle: news
+mode: default
+content:
+  addthis:
+    type: boolean_checkbox
+    weight: 11
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_content:
+    type: entity_reference_paragraphs
+    weight: 13
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: closed
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+  field_meta_tags:
+    type: metatag_firehose
+    weight: 12
+    region: content
+    settings:
+      sidebar: true
+      use_details: true
+    third_party_settings: {  }
+  field_news_category:
+    type: entity_reference_autocomplete_tags
+    weight: 2
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_news_description:
+    type: text_textarea
+    weight: 12
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_news_image:
+    type: entity_browser_entity_reference
+    weight: 11
+    region: content
+    settings:
+      entity_browser: images_library
+      field_widget_display: rendered_entity
+      field_widget_edit: true
+      field_widget_remove: true
+      field_widget_replace: false
+      open: false
+      field_widget_display_settings:
+        view_mode: half_without_blazy
+      selection_mode: selection_append
+    third_party_settings: {  }
+  field_news_location:
+    type: options_select
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_news_related:
+    type: entity_reference_autocomplete
+    weight: 11
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_sidebar_content:
+    type: entity_reference_paragraphs
+    weight: 12
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: closed
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 3
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 7
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 13
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  redirect:
+    type: string_textfield
+    weight: 30
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 120
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 8
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 9
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 14
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/openy_node/modules/openy_node_news/openy_node_news.install
+++ b/openy_node/modules/openy_node_news/openy_node_news.install
@@ -119,3 +119,15 @@ function openy_node_news_update_8007() {
     'image.style.node_news_teaser',
   ]);
 }
+
+/**
+ * Update display settings for image field for news node type.
+ */
+function openy_node_news_update_8008() {
+  $config_dir = \Drupal::service('extension.list.module')->getPath('openy_node_news') . '/config/optional';
+  $config_importer = \Drupal::service('config_import.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'core.entity_form_display.node.news.default',
+  ]);
+}


### PR DESCRIPTION
**Steps to reproduce:**

1. Login as an admin.
2. Navigate to Content → Add content → News Post.
3. In the Image field, upload a media item.
4. Notice that the image is not rendered correctly during content creation.

![image](https://github.com/user-attachments/assets/2320447c-db67-4866-8503-9380bec6061b)

✅ **Solution:**
The form display setting for the Image field was updated to use Render entity with the Half without Blazy view mode. 

![image](https://github.com/user-attachments/assets/650b0849-8bd0-4ebe-a4df-64093a193828)
