### PR TITLE
fix: remove   - drupal:ckeditor5_font from openy_editor

### DIFF
--- a/openy_editor/openy_editor.info.yml
+++ b/openy_editor/openy_editor.info.yml
@@ -8,7 +8,6 @@ dependencies:
   - colorbutton:colorbutton
   - ckeditor_bootstrap_buttons:ckeditor_bootstrap_buttons
   - drupal:ckeditor5
-  - drupal:ckeditor5_font
   - drupal:ckeditor5_paste_filter
   - drupal:editor
   - ckeditor_font:ckeditor_font


### PR DESCRIPTION
fix for https://github.com/open-y-subprojects/openy_features/pull/98