### PR TITLE
Update openy_editor.info.yml remove colorbutton dependency

### DIFF
--- a/openy_editor/openy_editor.info.yml
+++ b/openy_editor/openy_editor.info.yml
@@ -8,7 +8,6 @@ dependencies:
   - drupal:ckeditor5
   - drupal:ckeditor5_paste_filter
   - drupal:editor
-  - ckeditor_font:ckeditor_font
   - drupal:filter
   - entity_embed:entity_embed
   - token_filter:token_filter

--- a/openy_editor/openy_editor.info.yml
+++ b/openy_editor/openy_editor.info.yml
@@ -5,7 +5,6 @@ core_version_requirement: ^10 || ^11
 package: Open Y
 version: 2.0.0
 dependencies:
-  - ckeditor_bootstrap_buttons:ckeditor_bootstrap_buttons
   - drupal:ckeditor5
   - drupal:ckeditor5_paste_filter
   - drupal:editor

--- a/openy_editor/openy_editor.info.yml
+++ b/openy_editor/openy_editor.info.yml
@@ -5,7 +5,6 @@ core_version_requirement: ^10 || ^11
 package: Open Y
 version: 2.0.0
 dependencies:
-  - colorbutton:colorbutton
   - ckeditor_bootstrap_buttons:ckeditor_bootstrap_buttons
   - drupal:ckeditor5
   - drupal:ckeditor5_paste_filter


### PR DESCRIPTION
https://www.drupal.org/project/colorbutton and ckeditor_bootstrap_buttons,  ckeditor_font did not have drupal 11 version at this moment and we remove it from composer dependencies