### PR TITLE
fix(openy_user): remove google_analytics hard dependency

### DIFF
--- a/openy_user/openy_user.info.yml
+++ b/openy_user/openy_user.info.yml
@@ -8,4 +8,3 @@ dependencies:
   - drupal:user
   - openy_popups
   - openy_node_alert
-  - drupal:google_analytics


### PR DESCRIPTION
## Summary

- Remove `drupal:google_analytics` from `openy_user.info.yml` dependencies
- `openy_user` does not use `google_analytics` — the dependency is unnecessary

## Problem

When `google_analytics` is uninstalled (e.g. by `openy_post_update_uninstall_google_analytics` in yusaopeny 11.3), Drupal cascades the uninstall to `openy_user` because of this hard dependency. `openy_user` ships `user.role.*` configs (anonymous, authenticated, administrator, contributor, editor) in `config/install/`. When `openy_user` is uninstalled, all these role configs are deleted, causing **403 Access Denied on all pages** for anonymous users.

## Steps to reproduce

1. Have a site with `google_analytics` and `openy_user` enabled
2. Run `drush updb` with yusaopeny 11.3 (triggers `openy_post_update_uninstall_google_analytics`)
3. `google_analytics` is uninstalled → cascades to `openy_user` → all roles deleted → 403

## Test plan

- [ ] Verify `openy_user` still installs correctly without `google_analytics`
- [ ] Verify uninstalling `google_analytics` does not cascade to `openy_user`
- [ ] Verify all user roles remain intact after `google_analytics` uninstall