### PR TITLE
fix: remove google_analytics permission from authenticated role

### DIFF
--- a/openy_user/config/install/user.role.authenticated.yml
+++ b/openy_user/config/install/user.role.authenticated.yml
@@ -8,6 +8,5 @@ is_admin: false
 permissions:
   - 'access content'
   - 'access popups'
-  - 'opt-in or out of google analytics tracking'
   - 'restful get alerts_rest_resource'
   - 'view media'

--- a/openy_user/openy_user.install
+++ b/openy_user/openy_user.install
@@ -99,3 +99,17 @@ function openy_user_update_8008() {
     }
   }
 }
+
+/**
+ * Remove google_analytics permission from all roles.
+ */
+function openy_user_update_8009() {
+  $permission = 'opt-in or out of google analytics tracking';
+  $roles = \Drupal::entityTypeManager()->getStorage('user_role')->loadMultiple();
+  foreach ($roles as $role) {
+    if ($role->hasPermission($permission)) {
+      $role->revokePermission($permission);
+      $role->save();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Remove `opt-in or out of google analytics tracking` permission from `user.role.authenticated` config
- The `google_analytics` module dependency was already removed in a previous commit, but the permission remained in config causing errors

## Problem
During site install or `drush updb`, Drupal throws:
```
[error] Non-existent permission(s) assigned to role "Authenticated user" (authenticated) were removed. Invalid permission(s): opt-in or out of google analytics tracking.
```

## Test plan
- [ ] Fresh site install completes without permission errors