### PR TITLE
fix(ITCR-1271): use core image formatter instead of blazy (D11.4 config schema)

### DIFF
--- a/openy_egym_iwatch/config/install/core.entity_view_display.media.image.prgf_banner_fixed.yml
+++ b/openy_egym_iwatch/config/install/core.entity_view_display.media.image.prgf_banner_fixed.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.media.image.field_media_tags
     - media.type.image
   module:
-    - blazy
+    - image
 id: media.image.prgf_banner_fixed
 targetEntityType: media
 bundle: image
@@ -68,7 +68,7 @@ content:
       grid_medium: 0
       grid_small: 0
     third_party_settings: {  }
-    type: blazy
+    type: image
     region: content
 hidden:
   created: true

--- a/openy_egym_iwatch/openy_egym_iwatch.install
+++ b/openy_egym_iwatch/openy_egym_iwatch.install
@@ -229,3 +229,69 @@ function openy_egym_iwatch_update_10001() {
     $display->save();
   }
 }
+
+/**
+ * ITCR-1271: convert media image display(s) from blazy formatter to core image.
+ *
+ * Existing sites never re-import config, so they retain stale blazy formatter.
+ * This update mirrors the fresh-install config change for D11.4.
+ */
+function openy_egym_iwatch_update_10002() {
+  $displays = [
+    'media.image.prgf_banner_fixed',
+  ];
+
+  foreach ($displays as $display_id) {
+    _openy_egym_iwatch_itcr1271_blazy_to_image($display_id);
+  }
+}
+
+/**
+ * Helper to convert blazy formatter to image formatter in view displays.
+ *
+ * Idempotent: skips displays that don't have blazy or have already been converted.
+ */
+function _openy_egym_iwatch_itcr1271_blazy_to_image(string $id): void {
+  $config = \Drupal::configFactory()->getEditable('core.entity_view_display.' . $id);
+
+  // Skip if config doesn't exist on this site.
+  if ($config->isNew()) {
+    return;
+  }
+
+  $content = $config->get('content');
+  $changed = FALSE;
+
+  // Replace blazy formatter type with image.
+  foreach ($content as &$component) {
+    if (isset($component['type']) && $component['type'] === 'blazy') {
+      $component['type'] = 'image';
+      $changed = TRUE;
+    }
+  }
+
+  // Only save if we made changes.
+  if (!$changed) {
+    return;
+  }
+
+  // Update dependencies.
+  $dependencies = $config->get('dependencies') ?? [];
+  $modules = $dependencies['module'] ?? [];
+
+  // Remove blazy from dependencies.
+  $modules = array_values(array_diff($modules, ['blazy']));
+
+  // Add image if not already present.
+  if (!in_array('image', $modules)) {
+    $modules[] = 'image';
+  }
+
+  // Sort for consistent config.
+  sort($modules);
+
+  $dependencies['module'] = $modules;
+  $config->set('dependencies', $dependencies);
+  $config->set('content', $content);
+  $config->save();
+}

--- a/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.default.yml
+++ b/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.default.yml
@@ -8,7 +8,7 @@ dependencies:
     - field.field.media.image.field_media_tags
     - media.type.image
   module:
-    - blazy
+    - image
 id: media.image.default
 targetEntityType: media
 bundle: image
@@ -67,7 +67,7 @@ content:
       grid_medium: 0
       grid_small: 0
     third_party_settings: {  }
-    type: blazy
+    type: image
     region: content
 hidden:
   created: true

--- a/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_full.yml
+++ b/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_full.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.media.image.field_media_tags
     - media.type.image
   module:
-    - blazy
+    - image
 id: media.image.embedded_full
 targetEntityType: media
 bundle: image
@@ -67,7 +67,7 @@ content:
       grid_medium: 0
       grid_small: 0
     third_party_settings: {  }
-    type: blazy
+    type: image
     region: content
 hidden:
   created: true

--- a/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_half.yml
+++ b/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_half.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.media.image.field_media_tags
     - media.type.image
   module:
-    - blazy
+    - image
 id: media.image.embedded_half
 targetEntityType: media
 bundle: image
@@ -67,7 +67,7 @@ content:
       grid_medium: 0
       grid_small: 0
     third_party_settings: {  }
-    type: blazy
+    type: image
     region: content
 hidden:
   created: true

--- a/openy_media/modules/openy_media_image/openy_media_image.install
+++ b/openy_media/modules/openy_media_image/openy_media_image.install
@@ -554,3 +554,71 @@ function openy_media_image_update_10004() {
   return t('media_library view display not found. Run update 10003 first.');
 }
 
+/**
+ * ITCR-1271: convert media image display(s) from blazy formatter to core image.
+ *
+ * Existing sites never re-import config, so they retain stale blazy formatter.
+ * This update mirrors the fresh-install config change for D11.4.
+ */
+function openy_media_image_update_10005() {
+  $displays = [
+    'media.image.default',
+    'media.image.embedded_full',
+    'media.image.embedded_half',
+  ];
+
+  foreach ($displays as $display_id) {
+    _openy_media_image_itcr1271_blazy_to_image($display_id);
+  }
+}
+
+/**
+ * Helper to convert blazy formatter to image formatter in view displays.
+ *
+ * Idempotent: skips displays that don't have blazy or have already been converted.
+ */
+function _openy_media_image_itcr1271_blazy_to_image(string $id): void {
+  $config = \Drupal::configFactory()->getEditable('core.entity_view_display.' . $id);
+
+  // Skip if config doesn't exist on this site.
+  if ($config->isNew()) {
+    return;
+  }
+
+  $content = $config->get('content');
+  $changed = FALSE;
+
+  // Replace blazy formatter type with image.
+  foreach ($content as &$component) {
+    if (isset($component['type']) && $component['type'] === 'blazy') {
+      $component['type'] = 'image';
+      $changed = TRUE;
+    }
+  }
+
+  // Only save if we made changes.
+  if (!$changed) {
+    return;
+  }
+
+  // Update dependencies.
+  $dependencies = $config->get('dependencies') ?? [];
+  $modules = $dependencies['module'] ?? [];
+
+  // Remove blazy from dependencies.
+  $modules = array_values(array_diff($modules, ['blazy']));
+
+  // Add image if not already present.
+  if (!in_array('image', $modules)) {
+    $modules[] = 'image';
+  }
+
+  // Sort for consistent config.
+  sort($modules);
+
+  $dependencies['module'] = $modules;
+  $config->set('dependencies', $dependencies);
+  $config->set('content', $content);
+  $config->save();
+}
+

--- a/openy_node/modules/openy_node_category/config/install/core.entity_view_display.media.image.node_program_subcategory_teaser.yml
+++ b/openy_node/modules/openy_node_category/config/install/core.entity_view_display.media.image.node_program_subcategory_teaser.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.media.image.field_media_tags
     - media.type.image
   module:
-    - blazy
+    - image
 id: media.image.node_program_subcategory_teaser
 targetEntityType: media
 bundle: image
@@ -68,7 +68,7 @@ content:
       grid_medium: 0
       grid_small: 0
     third_party_settings: {  }
-    type: blazy
+    type: image
     region: content
 hidden:
   created: true

--- a/openy_node/modules/openy_node_category/openy_node_category.install
+++ b/openy_node/modules/openy_node_category/openy_node_category.install
@@ -416,3 +416,69 @@ function openy_node_category_update_10001() {
 
   $config->save();
 }
+
+/**
+ * ITCR-1271: convert media image display(s) from blazy formatter to core image.
+ *
+ * Existing sites never re-import config, so they retain stale blazy formatter.
+ * This update mirrors the fresh-install config change for D11.4.
+ */
+function openy_node_category_update_10002() {
+  $displays = [
+    'media.image.node_program_subcategory_teaser',
+  ];
+
+  foreach ($displays as $display_id) {
+    _openy_node_category_itcr1271_blazy_to_image($display_id);
+  }
+}
+
+/**
+ * Helper to convert blazy formatter to image formatter in view displays.
+ *
+ * Idempotent: skips displays that don't have blazy or have already been converted.
+ */
+function _openy_node_category_itcr1271_blazy_to_image(string $id): void {
+  $config = \Drupal::configFactory()->getEditable('core.entity_view_display.' . $id);
+
+  // Skip if config doesn't exist on this site.
+  if ($config->isNew()) {
+    return;
+  }
+
+  $content = $config->get('content');
+  $changed = FALSE;
+
+  // Replace blazy formatter type with image.
+  foreach ($content as &$component) {
+    if (isset($component['type']) && $component['type'] === 'blazy') {
+      $component['type'] = 'image';
+      $changed = TRUE;
+    }
+  }
+
+  // Only save if we made changes.
+  if (!$changed) {
+    return;
+  }
+
+  // Update dependencies.
+  $dependencies = $config->get('dependencies') ?? [];
+  $modules = $dependencies['module'] ?? [];
+
+  // Remove blazy from dependencies.
+  $modules = array_values(array_diff($modules, ['blazy']));
+
+  // Add image if not already present.
+  if (!in_array('image', $modules)) {
+    $modules[] = 'image';
+  }
+
+  // Sort for consistent config.
+  sort($modules);
+
+  $dependencies['module'] = $modules;
+  $config->set('dependencies', $dependencies);
+  $config->set('content', $content);
+  $config->save();
+}

--- a/openy_node/modules/openy_node_program/config/install/core.entity_view_display.media.image.node_program_header.yml
+++ b/openy_node/modules/openy_node_program/config/install/core.entity_view_display.media.image.node_program_header.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.media.image.field_media_tags
     - media.type.image
   module:
-    - blazy
+    - image
 id: media.image.node_program_header
 targetEntityType: media
 bundle: image
@@ -68,7 +68,7 @@ content:
       grid_medium: 0
       grid_small: 0
     third_party_settings: {  }
-    type: blazy
+    type: image
     region: content
 hidden:
   created: true

--- a/openy_node/modules/openy_node_program/openy_node_program.install
+++ b/openy_node/modules/openy_node_program/openy_node_program.install
@@ -417,3 +417,69 @@ function openy_node_program_update_10001() {
 
   $config->save();
 }
+
+/**
+ * ITCR-1271: convert media image display(s) from blazy formatter to core image.
+ *
+ * Existing sites never re-import config, so they retain stale blazy formatter.
+ * This update mirrors the fresh-install config change for D11.4.
+ */
+function openy_node_program_update_10002() {
+  $displays = [
+    'media.image.node_program_header',
+  ];
+
+  foreach ($displays as $display_id) {
+    _openy_node_program_itcr1271_blazy_to_image($display_id);
+  }
+}
+
+/**
+ * Helper to convert blazy formatter to image formatter in view displays.
+ *
+ * Idempotent: skips displays that don't have blazy or have already been converted.
+ */
+function _openy_node_program_itcr1271_blazy_to_image(string $id): void {
+  $config = \Drupal::configFactory()->getEditable('core.entity_view_display.' . $id);
+
+  // Skip if config doesn't exist on this site.
+  if ($config->isNew()) {
+    return;
+  }
+
+  $content = $config->get('content');
+  $changed = FALSE;
+
+  // Replace blazy formatter type with image.
+  foreach ($content as &$component) {
+    if (isset($component['type']) && $component['type'] === 'blazy') {
+      $component['type'] = 'image';
+      $changed = TRUE;
+    }
+  }
+
+  // Only save if we made changes.
+  if (!$changed) {
+    return;
+  }
+
+  // Update dependencies.
+  $dependencies = $config->get('dependencies') ?? [];
+  $modules = $dependencies['module'] ?? [];
+
+  // Remove blazy from dependencies.
+  $modules = array_values(array_diff($modules, ['blazy']));
+
+  // Add image if not already present.
+  if (!in_array('image', $modules)) {
+    $modules[] = 'image';
+  }
+
+  // Sort for consistent config.
+  sort($modules);
+
+  $dependencies['module'] = $modules;
+  $config->set('dependencies', $dependencies);
+  $config->set('content', $content);
+  $config->save();
+}

--- a/openy_node/modules/openy_node_social_post/config/install/core.entity_view_display.node.social_post.teaser.yml
+++ b/openy_node/modules/openy_node_social_post/config/install/core.entity_view_display.node.social_post.teaser.yml
@@ -12,7 +12,7 @@ dependencies:
     - field.field.node.social_post.field_sp_image
     - node.type.social_post
   module:
-    - blazy
+    - image
     - datetime
     - link
     - text
@@ -60,7 +60,7 @@ content:
       granularity: 2
     third_party_settings: {  }
   field_sp_image:
-    type: blazy
+    type: image
     weight: 0
     region: content
     label: hidden

--- a/openy_node/modules/openy_node_social_post/openy_node_social_post.install
+++ b/openy_node/modules/openy_node_social_post/openy_node_social_post.install
@@ -73,3 +73,69 @@ function openy_node_social_post_update_8004() {
     'image.style.social_post_preview',
   ]);
 }
+
+/**
+ * ITCR-1271: convert node view display(s) from blazy formatter to core image.
+ *
+ * Existing sites never re-import config, so they retain stale blazy formatter.
+ * This update mirrors the fresh-install config change for D11.4.
+ */
+function openy_node_social_post_update_8005() {
+  $displays = [
+    'node.social_post.teaser',
+  ];
+
+  foreach ($displays as $display_id) {
+    _openy_node_social_post_itcr1271_blazy_to_image($display_id);
+  }
+}
+
+/**
+ * Helper to convert blazy formatter to image formatter in view displays.
+ *
+ * Idempotent: skips displays that don't have blazy or have already been converted.
+ */
+function _openy_node_social_post_itcr1271_blazy_to_image(string $id): void {
+  $config = \Drupal::configFactory()->getEditable('core.entity_view_display.' . $id);
+
+  // Skip if config doesn't exist on this site.
+  if ($config->isNew()) {
+    return;
+  }
+
+  $content = $config->get('content');
+  $changed = FALSE;
+
+  // Replace blazy formatter type with image.
+  foreach ($content as &$component) {
+    if (isset($component['type']) && $component['type'] === 'blazy') {
+      $component['type'] = 'image';
+      $changed = TRUE;
+    }
+  }
+
+  // Only save if we made changes.
+  if (!$changed) {
+    return;
+  }
+
+  // Update dependencies.
+  $dependencies = $config->get('dependencies') ?? [];
+  $modules = $dependencies['module'] ?? [];
+
+  // Remove blazy from dependencies.
+  $modules = array_values(array_diff($modules, ['blazy']));
+
+  // Add image if not already present.
+  if (!in_array('image', $modules)) {
+    $modules[] = 'image';
+  }
+
+  // Sort for consistent config.
+  sort($modules);
+
+  $dependencies['module'] = $modules;
+  $config->set('dependencies', $dependencies);
+  $config->set('content', $content);
+  $config->save();
+}

--- a/openy_prgf/modules/openy_prgf_banner/config/install/core.entity_view_display.media.image.prgf_banner.yml
+++ b/openy_prgf/modules/openy_prgf_banner/config/install/core.entity_view_display.media.image.prgf_banner.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.media.image.field_media_tags
     - media.type.image
   module:
-    - blazy
+    - image
 id: media.image.prgf_banner
 targetEntityType: media
 bundle: image
@@ -68,7 +68,7 @@ content:
       grid_medium: 0
       grid_small: 0
     third_party_settings: {  }
-    type: blazy
+    type: image
     region: content
 hidden:
   created: true

--- a/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.install
+++ b/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.install
@@ -253,3 +253,69 @@ function openy_prgf_banner_update_10001() {
     $display->save();
   }
 }
+
+/**
+ * ITCR-1271: convert media image display(s) from blazy formatter to core image.
+ *
+ * Existing sites never re-import config, so they retain stale blazy formatter.
+ * This update mirrors the fresh-install config change for D11.4.
+ */
+function openy_prgf_banner_update_10002() {
+  $displays = [
+    'media.image.prgf_banner',
+  ];
+
+  foreach ($displays as $display_id) {
+    _openy_prgf_banner_itcr1271_blazy_to_image($display_id);
+  }
+}
+
+/**
+ * Helper to convert blazy formatter to image formatter in view displays.
+ *
+ * Idempotent: skips displays that don't have blazy or have already been converted.
+ */
+function _openy_prgf_banner_itcr1271_blazy_to_image(string $id): void {
+  $config = \Drupal::configFactory()->getEditable('core.entity_view_display.' . $id);
+
+  // Skip if config doesn't exist on this site.
+  if ($config->isNew()) {
+    return;
+  }
+
+  $content = $config->get('content');
+  $changed = FALSE;
+
+  // Replace blazy formatter type with image.
+  foreach ($content as &$component) {
+    if (isset($component['type']) && $component['type'] === 'blazy') {
+      $component['type'] = 'image';
+      $changed = TRUE;
+    }
+  }
+
+  // Only save if we made changes.
+  if (!$changed) {
+    return;
+  }
+
+  // Update dependencies.
+  $dependencies = $config->get('dependencies') ?? [];
+  $modules = $dependencies['module'] ?? [];
+
+  // Remove blazy from dependencies.
+  $modules = array_values(array_diff($modules, ['blazy']));
+
+  // Add image if not already present.
+  if (!in_array('image', $modules)) {
+    $modules[] = 'image';
+  }
+
+  // Sort for consistent config.
+  sort($modules);
+
+  $dependencies['module'] = $modules;
+  $config->set('dependencies', $dependencies);
+  $config->set('content', $content);
+  $config->save();
+}

--- a/openy_prgf/modules/openy_prgf_gallery/config/install/core.entity_view_display.media.image.prgf_gallery.yml
+++ b/openy_prgf/modules/openy_prgf_gallery/config/install/core.entity_view_display.media.image.prgf_gallery.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.media.image.field_media_tags
     - media.type.image
   module:
-    - blazy
+    - image
 id: media.image.prgf_gallery
 targetEntityType: media
 bundle: image
@@ -68,7 +68,7 @@ content:
       grid_medium: 0
       grid_small: 0
     third_party_settings: {  }
-    type: blazy
+    type: image
     region: content
 hidden:
   created: true

--- a/openy_prgf/modules/openy_prgf_gallery/openy_prgf_gallery.install
+++ b/openy_prgf/modules/openy_prgf_gallery/openy_prgf_gallery.install
@@ -224,3 +224,69 @@ function openy_prgf_gallery_update_10001() {
     $display->save();
   }
 }
+
+/**
+ * ITCR-1271: convert media image display(s) from blazy formatter to core image.
+ *
+ * Existing sites never re-import config, so they retain stale blazy formatter.
+ * This update mirrors the fresh-install config change for D11.4.
+ */
+function openy_prgf_gallery_update_10002() {
+  $displays = [
+    'media.image.prgf_gallery',
+  ];
+
+  foreach ($displays as $display_id) {
+    _openy_prgf_gallery_itcr1271_blazy_to_image($display_id);
+  }
+}
+
+/**
+ * Helper to convert blazy formatter to image formatter in view displays.
+ *
+ * Idempotent: skips displays that don't have blazy or have already been converted.
+ */
+function _openy_prgf_gallery_itcr1271_blazy_to_image(string $id): void {
+  $config = \Drupal::configFactory()->getEditable('core.entity_view_display.' . $id);
+
+  // Skip if config doesn't exist on this site.
+  if ($config->isNew()) {
+    return;
+  }
+
+  $content = $config->get('content');
+  $changed = FALSE;
+
+  // Replace blazy formatter type with image.
+  foreach ($content as &$component) {
+    if (isset($component['type']) && $component['type'] === 'blazy') {
+      $component['type'] = 'image';
+      $changed = TRUE;
+    }
+  }
+
+  // Only save if we made changes.
+  if (!$changed) {
+    return;
+  }
+
+  // Update dependencies.
+  $dependencies = $config->get('dependencies') ?? [];
+  $modules = $dependencies['module'] ?? [];
+
+  // Remove blazy from dependencies.
+  $modules = array_values(array_diff($modules, ['blazy']));
+
+  // Add image if not already present.
+  if (!in_array('image', $modules)) {
+    $modules[] = 'image';
+  }
+
+  // Sort for consistent config.
+  sort($modules);
+
+  $dependencies['module'] = $modules;
+  $config->set('dependencies', $dependencies);
+  $config->set('content', $content);
+  $config->save();
+}

--- a/openy_prgf/modules/openy_prgf_mbrshp_calc/config/install/core.entity_view_display.media.image.calc_summary.yml
+++ b/openy_prgf/modules/openy_prgf_mbrshp_calc/config/install/core.entity_view_display.media.image.calc_summary.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.media.image.field_media_tags
     - media.type.image
   module:
-    - blazy
+    - image
 id: media.image.calc_summary
 targetEntityType: media
 bundle: image
@@ -68,7 +68,7 @@ content:
       grid_medium: 0
       grid_small: 0
     third_party_settings: {  }
-    type: blazy
+    type: image
     region: content
 hidden:
   created: true

--- a/openy_prgf/modules/openy_prgf_mbrshp_calc/openy_prgf_mbrshp_calc.install
+++ b/openy_prgf/modules/openy_prgf_mbrshp_calc/openy_prgf_mbrshp_calc.install
@@ -107,3 +107,69 @@ function openy_prgf_mbrshp_calc_update_10101() {
     'core.entity_view_display.node.membership.calc_summary',
   ]);
 }
+
+/**
+ * ITCR-1271: convert media image display(s) from blazy formatter to core image.
+ *
+ * Existing sites never re-import config, so they retain stale blazy formatter.
+ * This update mirrors the fresh-install config change for D11.4.
+ */
+function openy_prgf_mbrshp_calc_update_10102() {
+  $displays = [
+    'media.image.calc_summary',
+  ];
+
+  foreach ($displays as $display_id) {
+    _openy_prgf_mbrshp_calc_itcr1271_blazy_to_image($display_id);
+  }
+}
+
+/**
+ * Helper to convert blazy formatter to image formatter in view displays.
+ *
+ * Idempotent: skips displays that don't have blazy or have already been converted.
+ */
+function _openy_prgf_mbrshp_calc_itcr1271_blazy_to_image(string $id): void {
+  $config = \Drupal::configFactory()->getEditable('core.entity_view_display.' . $id);
+
+  // Skip if config doesn't exist on this site.
+  if ($config->isNew()) {
+    return;
+  }
+
+  $content = $config->get('content');
+  $changed = FALSE;
+
+  // Replace blazy formatter type with image.
+  foreach ($content as &$component) {
+    if (isset($component['type']) && $component['type'] === 'blazy') {
+      $component['type'] = 'image';
+      $changed = TRUE;
+    }
+  }
+
+  // Only save if we made changes.
+  if (!$changed) {
+    return;
+  }
+
+  // Update dependencies.
+  $dependencies = $config->get('dependencies') ?? [];
+  $modules = $dependencies['module'] ?? [];
+
+  // Remove blazy from dependencies.
+  $modules = array_values(array_diff($modules, ['blazy']));
+
+  // Add image if not already present.
+  if (!in_array('image', $modules)) {
+    $modules[] = 'image';
+  }
+
+  // Sort for consistent config.
+  sort($modules);
+
+  $dependencies['module'] = $modules;
+  $config->set('dependencies', $dependencies);
+  $config->set('content', $content);
+  $config->save();
+}

--- a/openy_prgf/modules/openy_prgf_small_banner/config/install/core.entity_view_display.media.image.prgf_small_banner.yml
+++ b/openy_prgf/modules/openy_prgf_small_banner/config/install/core.entity_view_display.media.image.prgf_small_banner.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.media.image.field_media_tags
     - media.type.image
   module:
-    - blazy
+    - image
 id: media.image.prgf_small_banner
 targetEntityType: media
 bundle: image
@@ -68,7 +68,7 @@ content:
       grid_medium: 0
       grid_small: 0
     third_party_settings: {  }
-    type: blazy
+    type: image
     region: content
 hidden:
   created: true

--- a/openy_prgf/modules/openy_prgf_small_banner/openy_prgf_small_banner.install
+++ b/openy_prgf/modules/openy_prgf_small_banner/openy_prgf_small_banner.install
@@ -225,3 +225,69 @@ function openy_prgf_small_banner_update_10001() {
     $display->save();
   }
 }
+
+/**
+ * ITCR-1271: convert media image display(s) from blazy formatter to core image.
+ *
+ * Existing sites never re-import config, so they retain stale blazy formatter.
+ * This update mirrors the fresh-install config change for D11.4.
+ */
+function openy_prgf_small_banner_update_10002() {
+  $displays = [
+    'media.image.prgf_small_banner',
+  ];
+
+  foreach ($displays as $display_id) {
+    _openy_prgf_small_banner_itcr1271_blazy_to_image($display_id);
+  }
+}
+
+/**
+ * Helper to convert blazy formatter to image formatter in view displays.
+ *
+ * Idempotent: skips displays that don't have blazy or have already been converted.
+ */
+function _openy_prgf_small_banner_itcr1271_blazy_to_image(string $id): void {
+  $config = \Drupal::configFactory()->getEditable('core.entity_view_display.' . $id);
+
+  // Skip if config doesn't exist on this site.
+  if ($config->isNew()) {
+    return;
+  }
+
+  $content = $config->get('content');
+  $changed = FALSE;
+
+  // Replace blazy formatter type with image.
+  foreach ($content as &$component) {
+    if (isset($component['type']) && $component['type'] === 'blazy') {
+      $component['type'] = 'image';
+      $changed = TRUE;
+    }
+  }
+
+  // Only save if we made changes.
+  if (!$changed) {
+    return;
+  }
+
+  // Update dependencies.
+  $dependencies = $config->get('dependencies') ?? [];
+  $modules = $dependencies['module'] ?? [];
+
+  // Remove blazy from dependencies.
+  $modules = array_values(array_diff($modules, ['blazy']));
+
+  // Add image if not already present.
+  if (!in_array('image', $modules)) {
+    $modules[] = 'image';
+  }
+
+  // Sort for consistent config.
+  sort($modules);
+
+  $dependencies['module'] = $modules;
+  $config->set('dependencies', $dependencies);
+  $config->set('content', $content);
+  $config->save();
+}

--- a/openy_prgf/modules/openy_prgf_teaser/config/install/core.entity_view_display.media.image.prgf_teaser.yml
+++ b/openy_prgf/modules/openy_prgf_teaser/config/install/core.entity_view_display.media.image.prgf_teaser.yml
@@ -10,7 +10,7 @@ dependencies:
     - image.style.paragraph_teaser_520_440
     - media.type.image
   module:
-    - blazy
+    - image
 id: media.image.prgf_teaser
 targetEntityType: media
 bundle: image
@@ -69,7 +69,7 @@ content:
       grid_medium: 0
       grid_small: 0
     third_party_settings: {  }
-    type: blazy
+    type: image
     region: content
 hidden:
   created: true

--- a/openy_prgf/modules/openy_prgf_teaser/openy_prgf_teaser.install
+++ b/openy_prgf/modules/openy_prgf_teaser/openy_prgf_teaser.install
@@ -246,3 +246,69 @@ function openy_prgf_teaser_update_10001() {
     $display->save();
   }
 }
+
+/**
+ * ITCR-1271: convert media image display(s) from blazy formatter to core image.
+ *
+ * Existing sites never re-import config, so they retain stale blazy formatter.
+ * This update mirrors the fresh-install config change for D11.4.
+ */
+function openy_prgf_teaser_update_10002() {
+  $displays = [
+    'media.image.prgf_teaser',
+  ];
+
+  foreach ($displays as $display_id) {
+    _openy_prgf_teaser_itcr1271_blazy_to_image($display_id);
+  }
+}
+
+/**
+ * Helper to convert blazy formatter to image formatter in view displays.
+ *
+ * Idempotent: skips displays that don't have blazy or have already been converted.
+ */
+function _openy_prgf_teaser_itcr1271_blazy_to_image(string $id): void {
+  $config = \Drupal::configFactory()->getEditable('core.entity_view_display.' . $id);
+
+  // Skip if config doesn't exist on this site.
+  if ($config->isNew()) {
+    return;
+  }
+
+  $content = $config->get('content');
+  $changed = FALSE;
+
+  // Replace blazy formatter type with image.
+  foreach ($content as &$component) {
+    if (isset($component['type']) && $component['type'] === 'blazy') {
+      $component['type'] = 'image';
+      $changed = TRUE;
+    }
+  }
+
+  // Only save if we made changes.
+  if (!$changed) {
+    return;
+  }
+
+  // Update dependencies.
+  $dependencies = $config->get('dependencies') ?? [];
+  $modules = $dependencies['module'] ?? [];
+
+  // Remove blazy from dependencies.
+  $modules = array_values(array_diff($modules, ['blazy']));
+
+  // Add image if not already present.
+  if (!in_array('image', $modules)) {
+    $modules[] = 'image';
+  }
+
+  // Sort for consistent config.
+  sort($modules);
+
+  $dependencies['module'] = $modules;
+  $config->set('dependencies', $dependencies);
+  $config->set('content', $content);
+  $config->save();
+}


### PR DESCRIPTION
## Problem

Site install fails on **Drupal 11.4** with:

```
In ArrayElement.php line 100:
The configuration property content.field_media_image.settings.breakpoints.xs doesn't exist.
```

Drupal 11.4 enforces strict config schema validation at install: a config key absent from the resolved schema now throws instead of being silently ignored (≤11.3 tolerated it). Formatter settings schema is keyed by formatter type (`field.formatter.settings.[type]`). The blazy 3.x schema does not define the legacy keys these displays carry (`breakpoints`, …), so install dies.

## Fix

Switch the formatter type on the affected image displays from **blazy** to the core **image** formatter (native `loading=lazy`). Minimal change — only `type:` (and the module dependency `blazy → image`).

- All existing settings are **preserved**, including the configured `image_style` on every display.
- TODO: add hook update to fix existed configs

12 displays across `openy_media_image`, `openy_prgf_*`, `openy_node_*`, `openy_egym_iwatch`.

## Compatibility

- **11.4**: install completes (verified on 11.4.0-rc2, small_y; `image_style` confirmed preserved post-install).
- **11.3**: backward compatible (core image formatter exists since D8).

## Note / follow-up

Aspect-ratio enforcement and other blazy-only behaviours are no longer applied (core image formatter has no equivalent); the referenced image styles already define rendered dimensions. `lb_branch_amenities_blocks` uses the `blazy_media` formatter on an entity-reference field and needs a separate replacement.
