### PR TITLE
Fix Blazy 2.x-RC/3.x formatter settings compat (breaks fresh openy install)

### DIFF
--- a/openy_egym_iwatch/config/install/core.entity_view_display.media.image.prgf_banner_fixed.yml
+++ b/openy_egym_iwatch/config/install/core.entity_view_display.media.image.prgf_banner_fixed.yml
@@ -19,54 +19,10 @@ content:
     weight: 0
     label: hidden
     settings:
-      image_style: prgf_banner_fixed
-      thumbnail_style: ''
-      media_switch: ''
-      ratio: enforced
-      sizes: ''
-      breakpoints:
-        xs:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        sm:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        md:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        lg:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        xl:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-      current_view_mode: prgf_banner_fixed
-      background: false
       caption:
         title: '0'
         alt: '0'
-      iframe_lazy: true
-      icon: ''
-      layout: ''
-      view_mode: ''
-      cache: 0
       optionset: default
-      skin: ''
-      style: ''
-      box_caption: ''
-      box_caption_custom: ''
-      box_style: ''
-      box_media_style: ''
-      responsive_image_style: ''
-      grid: 0
-      grid_header: ''
-      grid_medium: 0
-      grid_small: 0
     third_party_settings: {  }
     type: blazy
     region: content

--- a/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.default.yml
+++ b/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.default.yml
@@ -18,54 +18,10 @@ content:
     weight: 0
     label: hidden
     settings:
-      image_style: ''
-      thumbnail_style: ''
-      media_switch: ''
-      ratio: ''
-      sizes: ''
-      breakpoints:
-        xs:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        sm:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        md:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        lg:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        xl:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-      current_view_mode: default
-      background: false
       caption:
         title: '0'
         alt: '0'
-      iframe_lazy: true
-      icon: ''
-      layout: ''
-      view_mode: ''
-      cache: 0
       optionset: default
-      skin: ''
-      style: ''
-      box_caption: ''
-      box_caption_custom: ''
-      box_style: ''
-      box_media_style: ''
-      responsive_image_style: ''
-      grid: 0
-      grid_header: ''
-      grid_medium: 0
-      grid_small: 0
     third_party_settings: {  }
     type: blazy
     region: content

--- a/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_full.yml
+++ b/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_full.yml
@@ -19,53 +19,10 @@ content:
     weight: 0
     label: hidden
     settings:
-      image_style: media_full
-      thumbnail_style: ''
-      media_switch: ''
-      sizes: ''
-      breakpoints:
-        xs:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        sm:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        md:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        lg:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        xl:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-      current_view_mode: embedded_full
-      background: false
       caption:
         title: '0'
         alt: '0'
-      iframe_lazy: true
-      icon: ''
-      layout: ''
-      view_mode: ''
-      cache: 0
       optionset: default
-      skin: ''
-      style: ''
-      box_caption: ''
-      box_caption_custom: ''
-      box_style: ''
-      box_media_style: ''
-      responsive_image_style: ''
-      grid: 0
-      grid_header: ''
-      grid_medium: 0
-      grid_small: 0
     third_party_settings: {  }
     type: blazy
     region: content

--- a/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_half.yml
+++ b/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_half.yml
@@ -19,53 +19,10 @@ content:
     weight: 0
     label: hidden
     settings:
-      image_style: media_half
-      thumbnail_style: ''
-      media_switch: ''
-      sizes: ''
-      breakpoints:
-        xs:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        sm:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        md:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        lg:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        xl:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-      current_view_mode: embedded_half
-      background: false
       caption:
         title: '0'
         alt: '0'
-      iframe_lazy: true
-      icon: ''
-      layout: ''
-      view_mode: ''
-      cache: 0
       optionset: default
-      skin: ''
-      style: ''
-      box_caption: ''
-      box_caption_custom: ''
-      box_style: ''
-      box_media_style: ''
-      responsive_image_style: ''
-      grid: 0
-      grid_header: ''
-      grid_medium: 0
-      grid_small: 0
     third_party_settings: {  }
     type: blazy
     region: content

--- a/openy_node/modules/openy_node_category/config/install/core.entity_view_display.media.image.node_program_subcategory_teaser.yml
+++ b/openy_node/modules/openy_node_category/config/install/core.entity_view_display.media.image.node_program_subcategory_teaser.yml
@@ -19,54 +19,10 @@ content:
     weight: 0
     label: hidden
     settings:
-      image_style: node_program_subcategory_teaser
-      thumbnail_style: ''
-      media_switch: ''
-      ratio: enforced
-      sizes: ''
-      breakpoints:
-        xs:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        sm:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        md:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        lg:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        xl:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-      current_view_mode: node_program_subcategory_teaser
-      background: false
       caption:
         title: '0'
         alt: '0'
-      iframe_lazy: true
-      icon: ''
-      layout: ''
-      view_mode: ''
-      cache: 0
       optionset: default
-      skin: ''
-      style: ''
-      box_caption: ''
-      box_caption_custom: ''
-      box_style: ''
-      box_media_style: ''
-      responsive_image_style: ''
-      grid: 0
-      grid_header: ''
-      grid_medium: 0
-      grid_small: 0
     third_party_settings: {  }
     type: blazy
     region: content

--- a/openy_node/modules/openy_node_program/config/install/core.entity_view_display.media.image.node_program_header.yml
+++ b/openy_node/modules/openy_node_program/config/install/core.entity_view_display.media.image.node_program_header.yml
@@ -19,54 +19,10 @@ content:
     weight: 0
     label: hidden
     settings:
-      image_style: node_program_header
-      thumbnail_style: ''
-      media_switch: ''
-      ratio: ''
-      sizes: ''
-      breakpoints:
-        xs:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        sm:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        md:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        lg:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        xl:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-      current_view_mode: node_program_header
-      background: false
       caption:
         title: '0'
         alt: '0'
-      iframe_lazy: true
-      icon: ''
-      layout: ''
-      view_mode: ''
-      cache: 0
       optionset: default
-      skin: ''
-      style: ''
-      box_caption: ''
-      box_caption_custom: ''
-      box_style: ''
-      box_media_style: ''
-      responsive_image_style: ''
-      grid: 0
-      grid_header: ''
-      grid_medium: 0
-      grid_small: 0
     third_party_settings: {  }
     type: blazy
     region: content

--- a/openy_node/modules/openy_node_social_post/config/install/core.entity_view_display.node.social_post.teaser.yml
+++ b/openy_node/modules/openy_node_social_post/config/install/core.entity_view_display.node.social_post.teaser.yml
@@ -65,54 +65,10 @@ content:
     region: content
     label: hidden
     settings:
-      image_style: event_teaser
-      thumbnail_style: event_teaser
-      media_switch: content
-      background: true
-      ratio: '16:9'
-      sizes: ''
-      breakpoints:
-        xs:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        sm:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        md:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        lg:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        xl:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-      current_view_mode: teaser
       caption:
         title: '0'
         alt: '0'
-      iframe_lazy: true
-      icon: ''
-      layout: ''
-      view_mode: ''
-      cache: 0
       optionset: default
-      skin: ''
-      style: ''
-      box_caption: ''
-      box_caption_custom: ''
-      box_style: ''
-      box_media_style: ''
-      responsive_image_style: ''
-      grid: 0
-      grid_header: ''
-      grid_medium: 0
-      grid_small: 0
     third_party_settings: {  }
   links:
     weight: 5

--- a/openy_prgf/modules/openy_prgf_banner/config/install/core.entity_view_display.media.image.prgf_banner.yml
+++ b/openy_prgf/modules/openy_prgf_banner/config/install/core.entity_view_display.media.image.prgf_banner.yml
@@ -19,54 +19,10 @@ content:
     weight: 0
     label: hidden
     settings:
-      image_style: prgf_banner
-      thumbnail_style: ''
-      media_switch: ''
-      ratio: enforced
-      sizes: ''
-      breakpoints:
-        xs:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        sm:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        md:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        lg:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        xl:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-      current_view_mode: prgf_banner
-      background: false
       caption:
         title: '0'
         alt: '0'
-      iframe_lazy: true
-      icon: ''
-      layout: ''
-      view_mode: ''
-      cache: 0
       optionset: default
-      skin: ''
-      style: ''
-      box_caption: ''
-      box_caption_custom: ''
-      box_style: ''
-      box_media_style: ''
-      responsive_image_style: ''
-      grid: 0
-      grid_header: ''
-      grid_medium: 0
-      grid_small: 0
     third_party_settings: {  }
     type: blazy
     region: content

--- a/openy_prgf/modules/openy_prgf_gallery/config/install/core.entity_view_display.media.image.prgf_gallery.yml
+++ b/openy_prgf/modules/openy_prgf_gallery/config/install/core.entity_view_display.media.image.prgf_gallery.yml
@@ -19,54 +19,10 @@ content:
     weight: 0
     label: hidden
     settings:
-      image_style: prgf_gallery
-      thumbnail_style: ''
-      media_switch: ''
-      ratio: enforced
-      sizes: ''
-      breakpoints:
-        xs:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        sm:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        md:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        lg:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        xl:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-      current_view_mode: prgf_gallery
-      background: false
       caption:
         title: '0'
         alt: '0'
-      iframe_lazy: true
-      icon: ''
-      layout: ''
-      view_mode: ''
-      cache: 0
       optionset: default
-      skin: ''
-      style: ''
-      box_caption: ''
-      box_caption_custom: ''
-      box_style: ''
-      box_media_style: ''
-      responsive_image_style: ''
-      grid: 0
-      grid_header: ''
-      grid_medium: 0
-      grid_small: 0
     third_party_settings: {  }
     type: blazy
     region: content

--- a/openy_prgf/modules/openy_prgf_mbrshp_calc/config/install/core.entity_view_display.media.image.calc_summary.yml
+++ b/openy_prgf/modules/openy_prgf_mbrshp_calc/config/install/core.entity_view_display.media.image.calc_summary.yml
@@ -19,54 +19,10 @@ content:
     weight: 0
     label: hidden
     settings:
-      image_style: node_mbrshp_calc_summary
-      thumbnail_style: ''
-      media_switch: ''
-      ratio: enforced
-      sizes: ''
-      breakpoints:
-        xs:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        sm:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        md:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        lg:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        xl:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-      current_view_mode: calc_summary
-      background: false
       caption:
         title: '0'
         alt: '0'
-      iframe_lazy: true
-      icon: ''
-      layout: ''
-      view_mode: ''
-      cache: 0
       optionset: default
-      skin: ''
-      style: ''
-      box_caption: ''
-      box_caption_custom: ''
-      box_style: ''
-      box_media_style: ''
-      responsive_image_style: ''
-      grid: 0
-      grid_header: ''
-      grid_medium: 0
-      grid_small: 0
     third_party_settings: {  }
     type: blazy
     region: content

--- a/openy_prgf/modules/openy_prgf_small_banner/config/install/core.entity_view_display.media.image.prgf_small_banner.yml
+++ b/openy_prgf/modules/openy_prgf_small_banner/config/install/core.entity_view_display.media.image.prgf_small_banner.yml
@@ -19,54 +19,10 @@ content:
     weight: 0
     label: hidden
     settings:
-      image_style: prgf_small_banner
-      thumbnail_style: ''
-      media_switch: ''
-      ratio: enforced
-      sizes: ''
-      breakpoints:
-        xs:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        sm:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        md:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        lg:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        xl:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-      current_view_mode: prgf_small_banner
-      background: false
       caption:
         title: '0'
         alt: '0'
-      iframe_lazy: true
-      icon: ''
-      layout: ''
-      view_mode: ''
-      cache: 0
       optionset: default
-      skin: ''
-      style: ''
-      box_caption: ''
-      box_caption_custom: ''
-      box_style: ''
-      box_media_style: ''
-      responsive_image_style: ''
-      grid: 0
-      grid_header: ''
-      grid_medium: 0
-      grid_small: 0
     third_party_settings: {  }
     type: blazy
     region: content

--- a/openy_prgf/modules/openy_prgf_teaser/config/install/core.entity_view_display.media.image.prgf_teaser.yml
+++ b/openy_prgf/modules/openy_prgf_teaser/config/install/core.entity_view_display.media.image.prgf_teaser.yml
@@ -20,54 +20,10 @@ content:
     weight: 0
     label: hidden
     settings:
-      image_style: paragraph_teaser_520_440
-      thumbnail_style: ''
-      media_switch: ''
-      ratio: enforced
-      sizes: ''
-      breakpoints:
-        xs:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        sm:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        md:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        lg:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        xl:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-      current_view_mode: prgf_teaser
-      background: false
       caption:
         title: '0'
         alt: '0'
-      iframe_lazy: true
-      icon: ''
-      layout: ''
-      view_mode: ''
-      cache: 0
       optionset: default
-      skin: ''
-      style: ''
-      box_caption: ''
-      box_caption_custom: ''
-      box_style: ''
-      box_media_style: ''
-      responsive_image_style: ''
-      grid: 0
-      grid_header: ''
-      grid_medium: 0
-      grid_small: 0
     third_party_settings: {  }
     type: blazy
     region: content


### PR DESCRIPTION
## Summary

Fresh `openy` profile install fails during `drush site:install openy`:

```
InvalidArgumentException: The configuration property
content.field_media_image.settings.breakpoints.xs doesn't exist. in
Drupal\Core\Config\Schema\ArrayElement->get() (line 100 of
core/lib/Drupal/Core/Config/Schema/ArrayElement.php)
```

`drupal/blazy`'s own config schema (`blazy.schema.yml`, `blazy_base` mapping) only declares `caption` + `optionset` since the 2.x-RC removal of legacy 1.x Breakpoints for Responsive image. Blazy's own documented remedy for existing sites is to open the Field UI display and hit Update/Save, which re-emits the config in the new (much smaller) shape. A fresh install has no such resave step — it applies whatever `openy_features` ships as-is, so it fails outright with `drupal/blazy` `^2.4 || ~3.0.0 || ~3.1.0` (currently resolves 3.0.17).

## Changes

Stripped the `blazy` field formatter settings block down to the two properties `blazy_base` actually declares (`caption`, `optionset`) in all 12 shipped `core.entity_view_display.*.yml` configs that use `type: blazy`:

- `openy_egym_iwatch`
- `openy_media/modules/openy_media_image` (3 files)
- `openy_node/modules/openy_node_program`, `openy_node_social_post`, `openy_node_category`
- `openy_prgf/modules/openy_prgf_banner`, `openy_prgf_gallery`, `openy_prgf_mbrshp_calc`, `openy_prgf_small_banner`, `openy_prgf_teaser`

No visual regression beyond what upgrading to Blazy 2.x-RC/3.x already entails site-wide -- breakpoints-based responsive image switching was removed from the formatter itself by Blazy, not by this fix. Per-display customization (image_style, ratio, media_switch, background, etc.) that used to live inline on these fields now needs to move to a named Blazy "optionset" if/when that visual fidelity matters -- out of scope for this fix, which only unblocks install.

## Test plan

- [ ] `drush site:install openy` completes without the schema error
- [ ] Spot-check a page using each of the 12 displays renders an image without PHP errors (styling may differ from before the Blazy upgrade -- expected, not a regression introduced here)

/cc @svicervlad for review
