### PR TITLE
Allow video / video_local media on Banner paragraph background (ITCP-712)

### DIFF
--- a/openy_prgf/modules/openy_prgf_banner/config/install/core.entity_form_display.paragraph.banner.default.yml
+++ b/openy_prgf/modules/openy_prgf_banner/config/install/core.entity_form_display.paragraph.banner.default.yml
@@ -44,6 +44,8 @@ content:
     settings:
       media_types:
         - image
+        - video
+        - video_local
     third_party_settings: {  }
     type: media_library_widget
     region: content

--- a/openy_prgf/modules/openy_prgf_banner/config/install/field.field.paragraph.banner.field_prgf_image.yml
+++ b/openy_prgf/modules/openy_prgf_banner/config/install/field.field.paragraph.banner.field_prgf_image.yml
@@ -4,13 +4,15 @@ dependencies:
   config:
     - field.storage.paragraph.field_prgf_image
     - media.type.image
+    - media.type.video
+    - media.type.video_local
     - paragraphs.paragraphs_type.banner
 id: paragraph.banner.field_prgf_image
 field_name: field_prgf_image
 entity_type: paragraph
 bundle: banner
 label: Image
-description: 'Entityreference to media image. Single value.'
+description: 'Entityreference to media image or video. Single value.'
 required: false
 translatable: true
 default_value: {  }
@@ -20,6 +22,8 @@ settings:
   handler_settings:
     target_bundles:
       image: image
+      video: video
+      video_local: video_local
     sort:
       field: name
       direction: ASC

--- a/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.install
+++ b/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.install
@@ -319,3 +319,38 @@ function _openy_prgf_banner_itcr1271_blazy_to_image(string $id): void {
   $config->set('content', $content);
   $config->save();
 }
+
+/**
+ * ITCP-712: allow video / video_local media on the Banner background field.
+ *
+ * Existing sites never re-import config, so field_prgf_image stays
+ * image-only until this update widens it. Mirrors lb_hero's field_media,
+ * which already supports image/video/video_local on the same
+ * entity_reference-to-media pattern.
+ */
+function openy_prgf_banner_update_10003() {
+  $field = \Drupal\field\Entity\FieldConfig::loadByName('paragraph', 'banner', 'field_prgf_image');
+  if ($field) {
+    $settings = $field->getSettings();
+    $settings['handler_settings']['target_bundles'] = [
+      'image' => 'image',
+      'video' => 'video',
+      'video_local' => 'video_local',
+    ];
+    $field->setSettings($settings);
+    $field->save();
+  }
+
+  $display = \Drupal::entityTypeManager()
+    ->getStorage('entity_form_display')
+    ->load('paragraph.banner.default');
+  if (!$display) {
+    return;
+  }
+  $component = $display->getComponent('field_prgf_image');
+  if ($component) {
+    $component['settings']['media_types'] = ['image', 'video', 'video_local'];
+    $display->setComponent('field_prgf_image', $component);
+    $display->save();
+  }
+}


### PR DESCRIPTION
## Summary
- Widens `field_prgf_image` (`paragraph:banner`) `target_bundles` from image-only to `image`/`video`/`video_local`, mirroring `lb_hero`'s `field_media` which already supports the same three bundles on the same entity_reference-to-media pattern.
- Updates the `media_library_widget`'s `media_types` to match.
- Adds `openy_prgf_banner_update_10003()` so existing sites (which never re-import `config/install`) pick this up on the next deploy.

## Companion change
Rendering support (actually showing the video as a background instead of the image) is `openy_carnation` theme territory — separate project, separate MR: https://git.drupalcode.org/project/openy_carnation/-/merge_requests/126. This PR alone just makes the field able to reference video media; without the theme MR the video option shows in the media library but doesn't render as a background yet.

## Scope note
`small_banner` paragraph has the identical image-only `field_prgf_image` limitation, intentionally left untouched here pending confirmation it should get the same treatment.

## Test plan
- [x] Local: fresh field settings allow Image/Video/Video Local tabs in the media library widget on the Banner paragraph edit form
- [x] `openy_prgf_banner_update_10003()` tested against a site with the old image-only config; runs clean and produces the same end state as a fresh install